### PR TITLE
bug fix: match beginning of string, not beginning of any line in multiline string

### DIFF
--- a/lib/pdfkit/source.rb
+++ b/lib/pdfkit/source.rb
@@ -7,7 +7,7 @@ class PDFKit
     end
     
     def url?
-      @source.is_a?(String) && @source.match(/^http/)
+      @source.is_a?(String) && @source.match(/\Ahttp/)
     end
     
     def file?

--- a/spec/source_spec.rb
+++ b/spec/source_spec.rb
@@ -17,6 +17,11 @@ describe PDFKit::Source do
       source = PDFKit::Source.new('<blink>Oh Hai!</blink>')
       source.should_not be_url
     end
+
+    it "should return false if passed HTML with embedded urls at the beginning of a line" do
+      source = PDFKit::Source.new("<blink>Oh Hai!</blink>\nhttp://www.google.com")
+      source.should_not be_url
+    end
   end
   
   describe "#file?" do


### PR DESCRIPTION
test included.  I ran into this because I happen to have a page with a url on a line by itself.
