### PR TITLE
Added custom request and response headers

### DIFF
--- a/lib/pdfkit/middleware.rb
+++ b/lib/pdfkit/middleware.rb
@@ -28,6 +28,7 @@ class PDFKit
         
         headers["Content-Length"] = (body.respond_to?(:bytesize) ? body.bytesize : body.size).to_s
         headers["Content-Type"] = "application/pdf"
+        headers.store("Middleware", "PDFKit")
         
         response = [body]
       end
@@ -51,6 +52,7 @@ class PDFKit
         path = Pathname(env['PATH_INFO'])
         ['PATH_INFO','REQUEST_URI'].each { |e| env[e] = path.to_s.sub(/#{path.extname}$/,'')  } if path.extname == '.pdf'
         env['HTTP_ACCEPT'] = concat(env['HTTP_ACCEPT'], Rack::Mime.mime_type('.html'))
+        env['MIDDLEWARE'] = "PDFKit"
       end
       
       def concat(accepts, type)

--- a/spec/middleware_spec.rb
+++ b/spec/middleware_spec.rb
@@ -44,6 +44,11 @@ describe PDFKit::Middleware do
     it "should replace .pdf in REQUEST_URI when the extname is .pdf" do
       @pdf.send :set_request_to_render_as_pdf, @pdf_env
       @pdf_env['REQUEST_URI'].should == "file"
-    end    
+    end  
+    
+    it "should inform RAILS of itself by setting a request header" do
+      @pdf.send :set_request_to_render_as_pdf, @pdf_env
+      @pdf_env['MIDDLEWARE'].should == "PDFKit"
+    end
   end
 end


### PR DESCRIPTION
To improve the ability to test that a PDF has been generated, and is not a normal PDF file, this commit adds custom header variables which let both RAILS (request) and Cucumber (response) know that PDFKit is in use.

On the Rails side, this is helpful when used within the ApplicationController to check if a PDF is being generated using a `:before_filter` to change the `request.format` to `:pdf`
    before_filter :adjust_format_for_pdf

```
def adjust_format_for_pdf
  request.format = :pdf if pdf_request?
end

def pdf_request?
  request.headers["MIDDLEWARE"] == "PDFKIT"
end
```

Now a simple `respond_to` block can be used in a page's controller after an alias is registered

```
Mime::Type.register_alias "text/html", :pdf

respond_to do |format|
  format.html { render :layout => 'normal' }
  format.pdf  { render :layout => 'pdf' }
end
```

AND A cucumber a step can now be written as follows

```
Then /^I should expect a generated PDF file$/ do
  page.response_headers.values_at('Middleware')).to_s.should == "PDFKit"
end
```
