### PR TITLE
Meta tag parsing made more robust

### DIFF
--- a/lib/pdfkit/pdfkit.rb
+++ b/lib/pdfkit/pdfkit.rb
@@ -85,9 +85,10 @@ class PDFKit
 
       found = {}
       content.scan(/<meta [^>]*>/) do |meta|
-        puts PDFKit.configuration.meta_tag_prefix
-        name = meta.scan(/name=["']#{PDFKit.configuration.meta_tag_prefix}([^"']*)/)[0][0]
-        found[name] = meta.scan(/content=["']([^"']*)/)[0][0]
+        if meta.match(/name=["']#{PDFKit.configuration.meta_tag_prefix}/)
+          name = meta.scan(/name=["']#{PDFKit.configuration.meta_tag_prefix}([^"']*)/)[0][0]
+          found[name] = meta.scan(/content=["']([^"']*)/)[0][0]
+        end
       end
 
       found

--- a/spec/pdfkit_spec.rb
+++ b/spec/pdfkit_spec.rb
@@ -121,6 +121,20 @@ describe PDFKit do
       pdfkit.command[pdfkit.command.index('"--orientation"') + 1].should == '"Landscape"'
     end
 
+    it "should skip non-pdfkit meta tags" do
+      body = %{
+        <html>
+          <head>
+            <meta name="test-page_size" content="Legal"/>
+            <meta name="pdfkit-orientation" content="Landscape"/>
+          </head>
+          <br>
+        </html>
+      }
+      pdfkit = PDFKit.new(body)
+      pdfkit.command[pdfkit.command.index('"--orientation"') + 1].should == '"Landscape"'
+    end
+
   end
 
   context "#to_pdf" do


### PR DESCRIPTION
Meta tag detection used rexml. While this gives all the power of parsing
and working with XML, it is very strict on the input it accepts. On
bad markup it simply throw the towel and gave up on parsing.

As the detection of meta tags should not depend on bad (html) markup
much later in the file, the parsing is now ported to using Regular
Expression.
