### PR TITLE
to_pdf gets truncated 

### DIFF
--- a/lib/pdfkit/pdfkit.rb
+++ b/lib/pdfkit/pdfkit.rb
@@ -61,7 +61,7 @@ class PDFKit
     args = command(path)
     invoke = args.join(' ')
 
-    result = IO.popen(invoke, "w+") do |pdf|
+    result = IO.popen(invoke, "wb+") do |pdf|
       pdf.puts(@source.to_s) if @source.html?
       pdf.close_write
       pdf.gets(nil)


### PR DESCRIPTION
Add the binary mode to write the return stream, IO.popen(invoke, "wb+"). otherwise the method of to_pdf will gets truncated since pdf is a binary stream, I got this problem in Ruby 1.8.6 and Rails 1.2.3.
