### PR TITLE
PDFKit cannot find the wkhtmltopdf binary file in the gem wkhtmltopdf-binary when using Bundler

### DIFF
--- a/lib/pdfkit/configuration.rb
+++ b/lib/pdfkit/configuration.rb
@@ -17,7 +17,7 @@ class PDFKit
     end
 
     def wkhtmltopdf
-      @wkhtmltopdf ||= `which wkhtmltopdf`.chomp
+      @wkhtmltopdf ||= (defined?(Bundler) ? `bundle exec which wkhtmltopdf` : `which wkhtmltopdf`).chomp
     end
   end
 


### PR DESCRIPTION
We're using a gem that provides a binary file for wkhtmltopdf (the recommended wkhtmltopdf-binary gem).  On deployment to our production server we vendor our gems in vendor/bundler.  The binary file for wkhtmltopdf is therefore not in our load paths, so calling:

```
which wkhtmltopdf
```

will not return anything, and PDFKit thinks we don't have a proper binary file to utilize.

This pull request adds an additional check for Bundler.  If the Bundler library is present, we call

```
bundle exec which wkhtmltopdf
```

which will properly return the location of the vendored gem's binary file.
