### PR TITLE
gsub error on body in translate_paths --> gsub called for #<Array...>

### DIFF
--- a/lib/pdfkit/middleware.rb
+++ b/lib/pdfkit/middleware.rb
@@ -17,6 +17,7 @@ class PDFKit
 
       if rendering_pdf? && headers['Content-Type'] =~ /text\/html|application\/xhtml\+xml/
         body = response.respond_to?(:body) ? response.body : response.join
+        body = body.join if body.is_a?(Array)
         body = PDFKit.new(translate_paths(body, env), @options).to_pdf
         response = [body]
 


### PR DESCRIPTION
sometimes response.body is an array, make sure we don't pass that to translate_paths

Luke
