### PR TITLE
Support :except option in middleware.

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,12 @@ PDFKit comes with a middleware that allows users to get a PDF view of any page o
     config.middleware.use PDFKit::Middleware, {}, :only => '/public'
     config.middleware.use PDFKit::Middleware, {}, :only => ['/invoice', '/public']
 
+    # conditions can be regexps (either one or an array)
+    config.middleware.use PDFKit::Middleware, {}, :except => [%r[^/prawn], %r[^/secret]]
+
+    # conditions can be strings (either one or an array)
+    config.middleware.use PDFKit::Middleware, {}, :except => ['/secret']
+
 ## Troubleshooting
 
 *  **Single thread issue:** In development environments it is common to run a

--- a/lib/pdfkit/middleware.rb
+++ b/lib/pdfkit/middleware.rb
@@ -58,6 +58,17 @@ class PDFKit
             @request.path[0, pattern.length] == pattern
           end
         end
+      elsif request_path_is_pdf && @conditions[:except]
+        rules = [@conditions[:except]].flatten
+        rules.map do |pattern|
+          if pattern.is_a?(Regexp)
+            return false if @request.path =~ pattern
+          else
+            return false if @request.path[0, pattern.length] == pattern
+          end
+        end
+
+        return true
       else
         request_path_is_pdf
       end

--- a/spec/middleware_spec.rb
+++ b/spec/middleware_spec.rb
@@ -106,6 +106,94 @@ describe PDFKit::Middleware do
         end # string
 
       end
+
+      describe ":except" do
+
+        describe "regex" do
+          describe "one" do
+            before { mock_app({}, :except => %r[^/secret]) }
+
+            context "matching" do
+              specify do
+                get 'http://www.example.org/public/test.pdf'
+                last_response.headers["Content-Type"].should == "application/pdf"
+                last_response.body.bytesize.should == PDFKit.new("Hello world!").to_pdf.bytesize
+              end
+            end
+
+            context "not matching" do
+              specify do
+                get 'http://www.example.org/secret/test.pdf'
+                last_response.headers["Content-Type"].should == "text/html"
+                last_response.body.should == "Hello world!"
+              end
+            end
+          end # one regex
+
+          describe "multiple" do
+            before { mock_app({}, :except => [%r[^/prawn], %r[^/secret]]) }
+
+            context "matching" do
+              specify do
+                get 'http://www.example.org/public/test.pdf'
+                last_response.headers["Content-Type"].should == "application/pdf"
+                last_response.body.bytesize.should == PDFKit.new("Hello world!").to_pdf.bytesize
+              end
+            end
+
+            context "not matching" do
+              specify do
+                get 'http://www.example.org/secret/test.pdf'
+                last_response.headers["Content-Type"].should == "text/html"
+                last_response.body.should == "Hello world!"
+              end
+            end
+          end # multiple regex
+        end # regex
+
+        describe "string" do
+          describe "one" do
+            before { mock_app({}, :except => '/secret') }
+
+            context "matching" do
+              specify do
+                get 'http://www.example.org/public/test.pdf'
+                last_response.headers["Content-Type"].should == "application/pdf"
+                last_response.body.bytesize.should == PDFKit.new("Hello world!").to_pdf.bytesize
+              end
+            end
+
+            context "not matching" do
+              specify do
+                get 'http://www.example.org/secret/test.pdf'
+                last_response.headers["Content-Type"].should == "text/html"
+                last_response.body.should == "Hello world!"
+              end
+            end
+          end # one string
+
+          describe "multiple" do
+            before { mock_app({}, :except => ['/prawn', '/secret']) }
+
+            context "matching" do
+              specify do
+                get 'http://www.example.org/public/test.pdf'
+                last_response.headers["Content-Type"].should == "application/pdf"
+                last_response.body.bytesize.should == PDFKit.new("Hello world!").to_pdf.bytesize
+              end
+            end
+
+            context "not matching" do
+              specify do
+                get 'http://www.example.org/secret/test.pdf'
+                last_response.headers["Content-Type"].should == "text/html"
+                last_response.body.should == "Hello world!"
+              end
+            end
+          end # multiple string
+        end # string
+
+      end
     end
 
     describe "remove .pdf from PATH_INFO and REQUEST_URI" do


### PR DESCRIPTION
The :except option in the middleware specification accepts the same kind
of parameters as the :only option. A possible usecase is to use direct
PDF rendering using prawn or another library for specific views but use
PDFKit for all other pages.
