### PR TITLE
Middleware breaks route when working on subdomain

### DIFF
--- a/lib/pdfkit/middleware.rb
+++ b/lib/pdfkit/middleware.rb
@@ -76,8 +76,12 @@ class PDFKit
 
     def set_request_to_render_as_pdf(env)
       @render_pdf = true
+
       path = @request.path.sub(%r{\.pdf$}, '')
+      path = path.sub(@request.script_name, '')
+
       %w[PATH_INFO REQUEST_URI].each { |e| env[e] = path }
+
       env['HTTP_ACCEPT'] = concat(env['HTTP_ACCEPT'], Rack::Mime.mime_type('.html'))
       env["Rack-Middleware-PDFKit"] = "true"
     end


### PR DESCRIPTION
I've realized that PDFKit on a subdomain doesn't handle the path correctly and brakes the routing of the application.

The problem is about the environment parameter SCRIPT_NAME, which has to be taken out of the 'path' variable in the method #set_request_to_render_as_pdf at line 80.

I fixed this problem and wrote a couple of tests. BTW: I haven't found a nice way to set the env['SCRIPT_NAME'] value in the top #mock_app method, so I just created a custom one just before executing the corresponding tests.
