### PR TITLE
#129: Support for few values for one key

### DIFF
--- a/lib/pdfkit/pdfkit.rb
+++ b/lib/pdfkit/pdfkit.rb
@@ -129,6 +129,8 @@ class PDFKit
       case value
       when TrueClass
         nil
+      when Array
+        value
       else
         value.to_s
       end

--- a/spec/pdfkit_spec.rb
+++ b/spec/pdfkit_spec.rb
@@ -134,6 +134,12 @@ describe PDFKit do
       pdfkit = PDFKit.new(body)
       pdfkit.command[pdfkit.command.index('"--orientation"') + 1].should == '"Landscape"'
     end
+    
+    it "should support few values for one key" do
+      pdfkit = PDFKit.new('html', cookie: ['name', 'value'])
+      pdfkit.command.should include("\"name\"")
+      pdfkit.command.should include("\"value\"")
+    end
 
   end
 


### PR DESCRIPTION
Add ability to do smth like this PDFKit.new('http://example.com', cookie: ["name", "value"])
For multivalues attributes like ---cookie or --custom-header for example.
Patch for #129.
