### PR TITLE
Escape backslashes in style-sheets

### DIFF
--- a/lib/pdfkit/pdfkit.rb
+++ b/lib/pdfkit/pdfkit.rb
@@ -95,7 +95,7 @@ class PDFKit
     end
 
     def style_tag_for(stylesheet)
-      "<style>#{File.read(stylesheet)}</style>"
+      "<style>#{File.read(stylesheet)}</style>".gsub('\\', '\\\\\\\\')
     end
 
     def append_stylesheets


### PR DESCRIPTION
Escape backslashes in style-sheets because it can cause incorrect replace in gsub.

For example in this part of Twitter Bootstrap CSS:

```
blockquote small:before{content:'\2014 \00A0'}blockquote.pull-right
```

\2 and \0 will be interpreted as gsub substitution patterns.
