### PR TITLE
Check wkhtmltopdf exit status for success, instead of just looking at output

### DIFF
--- a/lib/pdfkit/pdfkit.rb
+++ b/lib/pdfkit/pdfkit.rb
@@ -68,7 +68,8 @@ class PDFKit
     end
     result = File.read(path) if path
 
-    raise "command failed: #{invoke}" if result.to_s.strip.empty?
+    # $? is thread safe per http://stackoverflow.com/questions/2164887/thread-safe-external-process-in-ruby-plus-checking-exitstatus
+    raise "command failed: #{invoke}" if result.to_s.strip.empty? or !$?.success?
     return result
   end
 

--- a/spec/pdfkit_spec.rb
+++ b/spec/pdfkit_spec.rb
@@ -187,6 +187,10 @@ describe PDFKit do
       pdfkit.source.to_s.should include("<style>#{File.read(css)}</style></head>")
     end
 
+    it "should throw an error if it is unable to connect" do
+      pdfkit = PDFKit.new("http://google.com/this-should-not-be-found/404.html")
+      lambda { pdfkit.to_pdf }.should raise_error
+    end
   end
 
   context "#to_file" do
@@ -232,5 +236,4 @@ describe PDFKit do
       File.exist?(@test_path).should be_false
     end
   end
-
 end


### PR DESCRIPTION
This patch updates PDFKit to check the exit status code from wkhtmltopdf. This way, if you expected the page load to be a success and it was not, you can detect it.
