### PR TITLE
Enable toc and cover options

### DIFF
--- a/lib/pdfkit/pdfkit.rb
+++ b/lib/pdfkit/pdfkit.rb
@@ -1,4 +1,11 @@
 class PDFKit
+  GLOBAL_OPTIONS = ["--collate", "--grayscale", "--page-size", "--page-height",
+                    "--orientation", "--lowquality", "--margin-top", "--margin-right",
+                    "--margin-bottom", "--margin-left","--title", '--encoding',
+                    "--disable-smart-shrinking"]
+
+  TOC_OPTIONS = ["--disable-dotted-lines", "--toc-header-text", "--toc-level-indentation",
+                 "--disable-toc-links", "--toc-text-size-shrink", "--xsl-style-sheet"]
 
   class NoExecutableError < StandardError
     def initialize
@@ -32,13 +39,37 @@ class PDFKit
   def command(path = nil)
     args = [executable]
     args << '--quiet'
-    args += @options.to_a.flatten.compact
+
+    temp_options = @options.clone
+
+
+    global_options = temp_options.to_a - temp_options.delete_if{|key, value| GLOBAL_OPTIONS.include?(key) }.to_a
+    if global_options
+      args += global_options.flatten.compact
+    end
+
+    if temp_options.has_key?("cover")
+      temp_option = temp_options.delete("cover")
+      args += {"cover" => temp_option}.to_a.flatten.compact
+    end
+
+    if temp_options.has_key?("toc")
+      temp_option = temp_options.delete("toc")
+      args += {"toc" => temp_option}.to_a.flatten.compact
+    end
+
+    toc_options = temp_options.to_a - temp_options.delete_if{|key, value| TOC_OPTIONS.include?(key) }.to_a
+    if toc_options
+      args += toc_options.flatten.compact
+    end
 
     if @source.html?
       args << '-' # Get HTML from stdin
     else
       args << @source.to_s
     end
+
+    args += temp_options.to_a.flatten.compact
 
     args << (path || '-') # Write to file or stdout
 

--- a/spec/pdfkit_spec.rb
+++ b/spec/pdfkit_spec.rb
@@ -153,13 +153,66 @@ describe PDFKit do
       body = %{
         <html>
           <head>
+            <meta name="pdfkit-default-header" />
+            <meta name="pdfkit-javascript-delay" content="20" />
+          </head>
+        </html>
+      }
+      pdfkit = PDFKit.new(body)
+      pdfkit.command[pdfkit.command.index('"--default-header"') + 1][0..2].should == '"--'
+    end
+
+    it "should put toc option just before the page and page options" do
+      body = %{
+        <html>
+          <head>
+            <meta name="pdfkit-toc" />
+            <meta name="pdfkit-javascript-delay" content="20" />
+          </head>
+        </html>
+      }
+      pdfkit = PDFKit.new(body)
+      pdfkit.command[pdfkit.command.index('"toc"') + 1].should == '"-"'
+    end
+
+    it "should put a toc-option right after toc" do
+      body = %{
+        <html>
+          <head>
+            <meta name="pdfkit-toc" />
+            <meta name="pdfkit-javascript-delay" content="20" />
+            <meta name="pdfkit-xsl-style-sheet" content="toc.xsl"/>
+          </head>
+        </html>
+      }
+      pdfkit = PDFKit.new(body)
+      pdfkit.command[pdfkit.command.index('"toc"') + 1].should == '"--xsl-style-sheet"'
+    end
+
+    it "should put cover before page and page options" do
+      body = %{
+        <html>
+          <head>
+            <meta name="pdfkit-cover" content="cover.html" />
+            <meta name="pdfkit-javascript-delay" content="20" />
+          </head>
+        </html>
+      }
+      pdfkit = PDFKit.new(body)
+      pdfkit.command[pdfkit.command.index('"cover"') + 2].should == '"-"'
+    end
+
+    it "should work for meta tags without content" do
+      body = %{
+        <html>
+          <head>
             <meta name="pdfkit-toc" />
             <meta name="pdfkit-orientation" content="Landscape" />
           </head>
         </html>
       }
       pdfkit = PDFKit.new(body)
-      pdfkit.command[pdfkit.command.index('"toc"') + 1][0..2].should == '"--'
+      pdfkit.command[pdfkit.command.index('"toc"') + 1][0..2].should == '"-"'
     end
 
   end


### PR DESCRIPTION
Don't prefix them with --, and allow metatags without content.

Moved --quiet to first command, otherwise it conflicted with the toc option when setting it. 

Sadly the order in which you set the meta tags is important when using toc, because wkhtmltopdf needs the toc options to be grouped, and after the toc tag.
