### PR TITLE
don't wrap shell args in quotes now that we're using shellescape

### DIFF
--- a/lib/pdfkit/pdfkit.rb
+++ b/lib/pdfkit/pdfkit.rb
@@ -44,7 +44,7 @@ class PDFKit
 
     args << (path || '-') # Write to file or stdout
 
-    args.map {|arg| "#{arg.shellescape}"}
+    args.map {|arg| arg.shellescape}
   end
 
   def executable


### PR DESCRIPTION
From the [shellescape documentation](http://www.ruby-doc.org/stdlib-1.9.3/libdoc/shellwords/rdoc/Shellwords.html#method-c-shellescape):

> Note that a resulted string should be used unquoted and is not intended for use in double quotes nor in single quotes.

This is not a merely academic detail, as the quoting used prior to this change means that paths with spaces will fail when outputting PDFs.
