### PR TITLE
Fix broken page numbers in 0.5.3

### DIFF
--- a/lib/pdfkit/pdfkit.rb
+++ b/lib/pdfkit/pdfkit.rb
@@ -44,7 +44,7 @@ class PDFKit
 
     args << (path || '-') # Write to file or stdout
 
-    args.map {|arg| arg.shellescape}
+    args.shelljoin
   end
 
   def executable
@@ -60,8 +60,7 @@ class PDFKit
   def to_pdf(path=nil)
     append_stylesheets
 
-    args = command(path)
-    invoke = args.join(' ')
+    invoke = command(path)
 
     result = IO.popen(invoke, "wb+") do |pdf|
       pdf.puts(@source.to_s) if @source.html?


### PR DESCRIPTION
Fix the [page] / [toPage] broken output while keeping shell escaping of arguments.

Bug:  https://github.com/pdfkit/pdfkit/issues/165

Using the `shelljoin` ruby method which essencially calls `shellescape` and correctly join arguments. The API of `PDFKit#command` has changed as it is now returning the command to invoke directly (not an array of args). Hope that's fine and no one is relying on it (the method is public)

Tests updated.
