### PR TITLE
Don't require the wkhtmltopdf gem

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,9 @@
 rvm:
-- 1.8.7
 - 1.9.2
 - 1.9.3
+- 2.0.0
+
+before_script:
+  - "export DISPLAY=:99.0"
+  - "sh -e /etc/init.d/xvfb start"
+  - "sudo apt-get install wkhtmltopdf"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,7 +24,6 @@ GEM
     rspec-expectations (2.6.0)
       diff-lcs (~> 1.1.2)
     rspec-mocks (2.6.0)
-    wkhtmltopdf-binary (0.9.5.3)
 
 PLATFORMS
   ruby
@@ -37,4 +36,3 @@ DEPENDENCIES
   rake (~> 0.9.2)
   rdoc (~> 4.0.1)
   rspec (~> 2.2.0)
-  wkhtmltopdf-binary (~> 0.9.5)

--- a/pdfkit.gemspec
+++ b/pdfkit.gemspec
@@ -20,11 +20,10 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   # Developmnet Dependencies
+  s.add_development_dependency(%q<activesupport>, [">= 3.0.8"])
+  s.add_development_dependency(%q<mocha>, [">= 0.9.10"])
+  s.add_development_dependency(%q<rack-test>, [">= 0.5.6"])
   s.add_development_dependency(%q<rake>, ["~>0.9.2"])
   s.add_development_dependency(%q<rdoc>, ["~> 4.0.1"])
   s.add_development_dependency(%q<rspec>, ["~> 2.2.0"])
-  s.add_development_dependency(%q<mocha>, [">= 0.9.10"])
-  s.add_development_dependency(%q<rack-test>, [">= 0.5.6"])
-  s.add_development_dependency(%q<activesupport>, [">= 3.0.8"])
-  s.add_development_dependency(%q<wkhtmltopdf-binary>, ["~> 0.9.5"])
 end


### PR DESCRIPTION
It can be added/gem installed as needed. Also sort dependencies :).

One possible issue: will it need to be added to the gemfile/gemspec for
it to be picked up when running rake? Or will you be able to just `gem
install wkhtmltopdf`?
