### PR TITLE
Added escaping of ampersands in source url

### DIFF
--- a/lib/pdfkit/source.rb
+++ b/lib/pdfkit/source.rb
@@ -17,7 +17,19 @@ class PDFKit
     end
     
     def to_s
-      file? ? @source.path : @source
+      if file?
+        @source.path
+      elsif url?
+        escaped_url
+      else
+        @source
+      end
+    end
+
+    private
+
+    def escaped_url
+      @source.gsub '&', '\\\\&'
     end
   end
 end

--- a/spec/source_spec.rb
+++ b/spec/source_spec.rb
@@ -69,9 +69,16 @@ describe PDFKit::Source do
       source.to_s.should == __FILE__
     end
     
-    it "should return the url if passed a url like string" do
-      source = PDFKit::Source.new('http://google.com')
-      source.to_s.should == 'http://google.com'
+    context 'when the source is a url' do
+      it "should return the url" do
+        source = PDFKit::Source.new('http://google.com')
+        source.to_s.should == 'http://google.com'
+      end
+
+      it "should return the url with escaped ampersands" do
+        source = PDFKit::Source.new('http://google.com/?q=test&lang=en&country=us')
+        source.to_s.should == 'http://google.com/?q=test\\&lang=en\\&country=us'
+      end
     end
   end
   


### PR DESCRIPTION
When a URL contains an ampersand, i.e. it has multiple
query params, PDFKit should escape the ampersands so that
they can be passed to wkhtmltopdf. If the ampersands are
not escaped, Bash interprets as "run this in background"