### PR TITLE
Fixed bug to not add root url for protocl relative urls.

### DIFF
--- a/lib/pdfkit/middleware.rb
+++ b/lib/pdfkit/middleware.rb
@@ -36,13 +36,14 @@ class PDFKit
           headers.delete('ETag')
           headers.delete('Cache-Control')
         end
+
         if headers['PDFKit-save-pdf']
           File.open(headers['PDFKit-save-pdf'], 'wb') { |file| file.write(body) }
           headers.delete('PDFKit-save-pdf')
         end
 
-        headers["Content-Length"]         = (body.respond_to?(:bytesize) ? body.bytesize : body.size).to_s
-        headers["Content-Type"]           = "application/pdf"
+        headers['Content-Length']         = (body.respond_to?(:bytesize) ? body.bytesize : body.size).to_s
+        headers['Content-Type']           = 'application/pdf'
       end
 
       [status, headers, response]
@@ -55,7 +56,7 @@ class PDFKit
       # Host with protocol
       root = PDFKit.configuration.root_url || "#{env['rack.url_scheme']}://#{env['HTTP_HOST']}/"
 
-      body.gsub(/(href|src)=(['"])\/([^\"']*|[^"']*)['"]/, '\1=\2' + root + '\3\2')
+      body.gsub(/(href|src)=(['"])\/([^\/]([^\"']*|[^"']*))['"]/, '\1=\2' + root + '\3\2')
     end
 
     def rendering_pdf?
@@ -99,7 +100,7 @@ class PDFKit
       %w[PATH_INFO REQUEST_URI].each { |e| env[e] = path }
 
       env['HTTP_ACCEPT'] = concat(env['HTTP_ACCEPT'], Rack::Mime.mime_type('.html'))
-      env["Rack-Middleware-PDFKit"] = "true"
+      env['Rack-Middleware-PDFKit'] = 'true'
     end
 
     def concat(accepts, type)

--- a/spec/middleware_spec.rb
+++ b/spec/middleware_spec.rb
@@ -328,6 +328,12 @@ describe PDFKit::Middleware do
       body.should == "<link href=\"http://example.com/stylesheets/application.css\" media=\"screen\" rel=\"stylesheet\" type=\"text/css\" />"
     end
 
+    it "should correctly parse relative url with double quotes" do
+      @body = %{<link href='//fonts.googleapis.com/css?family=Open+Sans:400,600' rel='stylesheet' type='text/css'>}
+      body = @pdf.send :translate_paths, @body, @env
+      body.should == "<link href='//fonts.googleapis.com/css?family=Open+Sans:400,600' rel='stylesheet' type='text/css'>"
+    end
+
     it "should return the body even if there are no valid substitutions found" do
       @body = "NO MATCH"
       body = @pdf.send :translate_paths, @body, @env


### PR DESCRIPTION
Example I use http://www.paulirish.com/2010/the-protocol-relative-url/ in html layout.

``` html
<link href='//fonts.googleapis.com/css?family=Open+Sans:400,600' rel='stylesheet' type='text/css'>
```

and after run `translate_path` I got next:

``` html
<link href='http://example.com/fonts.googleapis.com/css?family=Open+Sans:400,600' rel='stylesheet' type='text/css'>
```
