### PR TITLE
Added ability to use strings with content true like boolean.

### DIFF
--- a/lib/pdfkit/pdfkit.rb
+++ b/lib/pdfkit/pdfkit.rb
@@ -152,10 +152,10 @@ class PDFKit
 
     def normalize_value(value)
       case value
-      when TrueClass #ie, ==true, see http://www.ruby-doc.org/core-1.9.3/TrueClass.html
+      when TrueClass, 'true' #ie, ==true, see http://www.ruby-doc.org/core-1.9.3/TrueClass.html
         nil
       when Hash
-        value.to_a.flatten.collect{|x| x.to_s}
+        value.to_a.flatten.collect{|x| normalize_value(x)}.compact
       when Array
         value.flatten.collect{|x| x.to_s}
       else

--- a/spec/pdfkit_spec.rb
+++ b/spec/pdfkit_spec.rb
@@ -153,6 +153,20 @@ describe PDFKit do
       command.should include "--cookie rails_session rails_session_value --cookie cookie_variable cookie_variable_value"
     end
 
+    it "should detect disable_smart_shrinking meta tag" do
+      body = %{
+        <html>
+          <head>
+            <meta name="pdfkit-disable_smart_shrinking" content="true"/>
+          </head>
+        </html>
+      }
+      pdfkit = PDFKit.new(body)
+      command = pdfkit.command
+      command.should include "--disable-smart-shrinking"
+      command.should_not include "--disable-smart-shrinking true"
+    end
+
     it "should detect special pdfkit meta tags despite bad markup" do
       body = %{
         <html>


### PR DESCRIPTION
When I tried to setup option for `disable_smart_shrinking` via meta tags.

``` html
<meta name="pdfkit-disable_smart_shrinking" content="true"/>
```

I had the generated command line with `--disable-smart-shrinking true`. 
