### PR TITLE
Allow to use repeatable options example like --cookie via meta tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,12 +40,15 @@ kit = PDFKit.new(File.new('/path/to/html'))
 
 # Add any kind of option through meta tags
 PDFKit.new('<html><head><meta name="pdfkit-page_size" content="Letter"')
+PDFKit.new('<html><head><meta name="pdfkit-cookie cookie_name1" content="cookie_value1"')
+PDFKit.new('<html><head><meta name="pdfkit-cookie cookie_name2" content="cookie_value2"')
 ```
 ### Using cookies in scraping
 If you want to pass a cookie to cookie to pdfkit to scrape a website, you can 
 pass it in a hash:
 ```ruby
-kit = PDFKit.new(url, cookie: {cookie_name, cookie_value})
+kit = PDFKit.new(url, cookie: {cookie_name: :cookie_value})
+kit = PDFKit.new(url, [:cookie, :cookie_name1] => :cookie_val1, [:cookie, :cookie_name2] => :cookie_val2)
 ```
 ## Configuration
 If you're on Windows or you installed wkhtmltopdf by hand to a location other than `/usr/local/bin` you will need to tell PDFKit where the binary is. You can configure PDFKit like so:

--- a/lib/pdfkit/pdfkit.rb
+++ b/lib/pdfkit/pdfkit.rb
@@ -88,8 +88,8 @@ class PDFKit
       found = {}
       content.scan(/<meta [^>]*>/) do |meta|
         if meta.match(/name=["']#{PDFKit.configuration.meta_tag_prefix}/)
-          name = meta.scan(/name=["']#{PDFKit.configuration.meta_tag_prefix}([^"']*)/)[0][0]
-          found[name.to_sym] = meta.scan(/content=["']([^"']*)/)[0][0]
+          name = meta.scan(/name=["']#{PDFKit.configuration.meta_tag_prefix}([^"']*)/)[0][0].split
+          found[name] = meta.scan(/content=["'](.*[^\\])["']/)[0][0]
         end
       end
 
@@ -117,7 +117,12 @@ class PDFKit
 
       options.each do |key, value|
         next if !value
-        normalized_key = "--#{normalize_arg key}"
+        normalized_key = if key.is_a? Array
+                           ["--#{normalize_arg key.first}"] + key[1..-1].map(&:to_s)
+                         else
+                           "--#{normalize_arg key}"
+                         end
+
         normalized_options[normalized_key] = normalize_value(value)
       end
       normalized_options

--- a/spec/pdfkit_spec.rb
+++ b/spec/pdfkit_spec.rb
@@ -61,6 +61,19 @@ describe PDFKit do
       command.should include "--replace foo bar"
     end
 
+    it "should setup one cookie only" do
+      pdfkit = PDFKit.new('html', cookie: {cookie_name: :cookie_value})
+      command = pdfkit.command
+      command.should include "--cookie cookie_name cookie_value"
+    end
+
+    it "should setup multiple cookies" do
+      pdfkit = PDFKit.new('html', [:cookie, :cookie_name1] => :cookie_val1, [:cookie, :cookie_name2] => :cookie_val2)
+      command = pdfkit.command
+      command.should include "--cookie cookie_name1 cookie_val1"
+      command.should include "--cookie cookie_name2 cookie_val2"
+    end
+
     it "will not include default options it is told to omit" do
       PDFKit.configure do |config|
         config.default_options[:disable_smart_shrinking] = true
@@ -117,6 +130,20 @@ describe PDFKit do
       command = pdfkit.command
       command.should include "--page-size Legal"
       command.should include "--orientation Landscape"
+    end
+
+    it "should detect cookies meta tag" do
+      body = %{
+        <html>
+          <head>
+            <meta name="pdfkit-cookie rails_session" content='rails_session_value' />
+            <meta name="pdfkit-cookie cookie_variable" content='cookie_variable_value' />
+          </head>
+        </html>
+      }
+      pdfkit = PDFKit.new(body)
+      command = pdfkit.command
+      command.should include "--cookie rails_session rails_session_value --cookie cookie_variable cookie_variable_value"
     end
 
     it "should detect special pdfkit meta tags despite bad markup" do


### PR DESCRIPTION
Added ability to setup `cookies` via meta tags.
