### PR TITLE
Ensure the returned string's encoding matches the options

### DIFF
--- a/lib/pdfkit/pdfkit.rb
+++ b/lib/pdfkit/pdfkit.rb
@@ -61,8 +61,9 @@ class PDFKit
     append_stylesheets
 
     invoke = command(path)
+    encoding = options['--encoding'] || 'ASCII-8BIT'
 
-    result = IO.popen(invoke, "wb+") do |pdf|
+    result = IO.popen(invoke, "wb+", :encoding => encoding) do |pdf|
       pdf.puts(@source.to_s) if @source.html?
       pdf.close_write
       pdf.gets(nil)

--- a/spec/pdfkit_spec.rb
+++ b/spec/pdfkit_spec.rb
@@ -299,6 +299,12 @@ describe PDFKit do
       pdf = pdfkit.to_pdf
       pdf[0...4].should == "%PDF" # PDF Signature at the beginning
     end
+
+    it "should generate PDF with the same encoding specified in the options" do
+      pdfkit = PDFKit.new("<html><body>this is some text</body></html>", encoding: 'utf-8')
+      pdf = pdfkit.to_pdf
+      pdf.encoding.to_s.should == 'UTF-8'
+    end
   end
 
   context "#to_file" do
@@ -320,7 +326,7 @@ describe PDFKit do
 
     it "should not truncate data (in Ruby 1.8.6)" do
       file_path = File.join(SPEC_ROOT,'fixtures','example.html')
-      pdfkit = PDFKit.new(File.new(file_path))
+      pdfkit = PDFKit.new(File.new(file_path), encoding: 'ASCII-8BIT')
       pdf_data = pdfkit.to_pdf
       file = pdfkit.to_file(@file_path)
       file_data = open(@file_path, 'rb') {|io| io.read }


### PR DESCRIPTION
We use to_pdf and then still do things with the returned string. We were hitting issues where the PDFKit to_pdf string was consistently returning a ASCII-8BIT string. Adding the option to set the encoding has resolved the issue without any side effects.
