### PR TITLE
Enable toc and cover options

### DIFF
--- a/lib/pdfkit/pdfkit.rb
+++ b/lib/pdfkit/pdfkit.rb
@@ -120,28 +120,32 @@ class PDFKit
     # https://github.com/wkhtmltopdf/wkhtmltopdf/blob/ebf9b6cfc4c58a31349fb94c568b254fac37b3d3/README_WKHTMLTOIMAGE#L27
     REPEATABLE_OPTIONS = %w[--allow --cookie --custom-header --post --post-file --run-script]
 
-    def find_options_in_meta(content)
-      # Read file if content is a File
-      content = content.read if content.is_a?(File)
+  def find_options_in_meta(content)
+    # Read file if content is a File
+    content = content.read if content.is_a?(File)
 
-      found = {}
-      content.scan(/<meta [^>]*>/) do |meta|
-        if meta.match(/name=["']#{PDFKit.configuration.meta_tag_prefix}/)
-          name = meta.scan(/name=["']#{PDFKit.configuration.meta_tag_prefix}([^"']*)/)[0][0]
-          found[name.to_sym] = meta.scan(/content=["']([^"']*)/)[0][0]
+    found = {}
+    content.scan(/<meta [^>]*>/) do |meta|
+      if meta.match(/name=["']#{PDFKit.configuration.meta_tag_prefix}/)
+        name = meta.scan(/name=["']#{PDFKit.configuration.meta_tag_prefix}([^"']*)/)[0][0].split
+        if meta.include?('content=')
+          found[name] = meta.scan(/content=["']([^"'\\]+)["']/)[0][0]
+        else
+          found[name]={}
         end
       end
-
-      tuple_keys = found.keys.select { |k| k.is_a? Array }
-      tuple_keys.each do |key|
-        value = found.delete key
-        new_key = key.shift
-        found[new_key] ||= {}
-        found[new_key][key] = value
-      end
-
-      found
     end
+
+    tuple_keys = found.keys.select { |k| k.is_a? Array }
+    tuple_keys.each do |key|
+      value = found.delete key
+      new_key = key.shift
+      found[new_key] ||= {}
+      found[new_key][key] = value
+    end
+
+    found
+  end
 
     def style_tag_for(stylesheet)
       "<style>#{File.read(stylesheet)}</style>"

--- a/lib/pdfkit/pdfkit.rb
+++ b/lib/pdfkit/pdfkit.rb
@@ -1,6 +1,13 @@
 require 'shellwords'
 
 class PDFKit
+  GLOBAL_OPTIONS = ["--collate", "--grayscale", "--page-size", "--page-height",
+                    "--orientation", "--lowquality", "--margin-top", "--margin-right",
+                    "--margin-bottom", "--margin-left","--title", '--encoding',
+                    "--disable-smart-shrinking"]
+
+  TOC_OPTIONS = ["--disable-dotted-lines", "--toc-header-text", "--toc-level-indentation",
+                 "--disable-toc-links", "--toc-text-size-shrink", "--xsl-style-sheet"]
 
   class NoExecutableError < StandardError
     def initialize
@@ -34,14 +41,39 @@ class PDFKit
 
   def command(path = nil)
     args = [executable]
-    args += @options.to_a.flatten.compact
     args << '--quiet'
+    args += @options.to_a.flatten.compact
+
+    temp_options = @options.clone
+
+
+    global_options = temp_options.to_a - temp_options.delete_if{|key, value| GLOBAL_OPTIONS.include?(key) }.to_a
+    if global_options
+      args += global_options.flatten.compact
+    end
+
+    if temp_options.has_key?("cover")
+      temp_option = temp_options.delete("cover")
+      args += {"cover" => temp_option}.to_a.flatten.compact
+    end
+
+    if temp_options.has_key?("toc")
+      temp_option = temp_options.delete("toc")
+      args += {"toc" => temp_option}.to_a.flatten.compact
+    end
+
+    toc_options = temp_options.to_a - temp_options.delete_if{|key, value| TOC_OPTIONS.include?(key) }.to_a
+    if toc_options
+      args += toc_options.flatten.compact
+    end
 
     if @source.html?
       args << '-' # Get HTML from stdin
     else
       args << @source.to_s
     end
+
+    args += temp_options.to_a.flatten.compact
 
     args << (path || '-') # Write to file or stdout
 

--- a/lib/pdfkit/pdfkit.rb
+++ b/lib/pdfkit/pdfkit.rb
@@ -33,7 +33,9 @@ class PDFKit
   end
 
   def command(path = nil)
-    args = @options.to_a.flatten.compact
+    args = [executable]
+    args += @options.to_a.flatten.compact
+    args << '--quiet'
 
     if @source.html?
       args << '-' # Get HTML from stdin
@@ -93,8 +95,8 @@ class PDFKit
       found = {}
       content.scan(/<meta [^>]*>/) do |meta|
         if meta.match(/name=["']#{PDFKit.configuration.meta_tag_prefix}/)
-          name = meta.scan(/name=["']#{PDFKit.configuration.meta_tag_prefix}([^"']*)/)[0][0].split
-          found[name] = meta.scan(/content=["']([^"'\\]+)["']/)[0][0]
+          name = meta.scan(/name=["']#{PDFKit.configuration.meta_tag_prefix}([^"']*)/)[0][0]
+          found[name.to_sym] = meta.scan(/content=["']([^"']*)/)[0][0]
         end
       end
 
@@ -130,18 +132,8 @@ class PDFKit
 
       options.each do |key, value|
         next if !value
-
-        # The actual option for wkhtmltopdf
         normalized_key = "--#{normalize_arg key}"
-
-        # If the option is repeatable, attempt to normalize all values
-        if REPEATABLE_OPTIONS.include? normalized_key
-          normalize_repeatable_value(value) do |normalized_key_piece, normalized_value|
-            normalized_options[[normalized_key, normalized_key_piece]] = normalized_value
-          end
-        else # Otherwise, just normalize it like usual
-          normalized_options[normalized_key] = normalize_value(value)
-        end
+        normalized_options[normalized_key] = normalize_value(value)
       end
 
       normalized_options

--- a/lib/pdfkit/pdfkit.rb
+++ b/lib/pdfkit/pdfkit.rb
@@ -43,7 +43,6 @@ class PDFKit
 
   def command(path = nil)
     args = []
-    args << '--quiet' unless PDFKit.configuration.verbose?
 
     temp_options = @options.clone
 

--- a/lib/pdfkit/pdfkit.rb
+++ b/lib/pdfkit/pdfkit.rb
@@ -165,13 +165,25 @@ class PDFKit
 
       options.each do |key, value|
         next if !value
+
+        # The actual option for wkhtmltopdf
         normalize_arg = normalize_arg key
         normalized_key = (NO_EXPAND_OPTIONS.include? normalize_arg) ? normalize_arg : "--#{normalize_arg}"
-        normalized_options[normalized_key] = normalize_value(value)
+
+        # If the option is repeatable, attempt to normalize all values
+        if REPEATABLE_OPTIONS.include? normalized_key
+          normalize_repeatable_value(value) do |normalized_key_piece, normalized_value|
+            normalized_options[[normalized_key, normalized_key_piece]] = normalized_value
+          end
+        else # Otherwise, just normalize it like usual
+          normalized_options[normalized_key] = normalize_value(value)
+        end
       end
 
       normalized_options
     end
+
+
 
     def normalize_arg(arg)
       arg.to_s.downcase.gsub(/[^a-z0-9]/,'-')

--- a/spec/pdfkit_spec.rb
+++ b/spec/pdfkit_spec.rb
@@ -68,7 +68,7 @@ describe PDFKit do
 
     it "should not break Windows paths" do
       pdfkit = PDFKit.new('html')
-      PDFKit.configuration.stub(:wkhtmltopdf) { 'c:/Program Files/wkhtmltopdf/wkhtmltopdf.exe' }
+      allow(PDFKit.configuration).to receive(:wkhtmltopdf) { 'c:/Program Files/wkhtmltopdf/wkhtmltopdf.exe' }
       expect(pdfkit.command).not_to include('Program\ Files')
     end
 
@@ -251,8 +251,8 @@ describe PDFKit do
         </html>
       }
       pdfkit = PDFKit.new(body)
-      pdfkit.command[pdfkit.command.index('toc') - 1].should == ' '
-      pdfkit.command[pdfkit.command.index('cover') - 1].should == ' '
+      expect(pdfkit.command[pdfkit.command.index('toc') - 1]).to eql ' '
+      expect(pdfkit.command[pdfkit.command.index('cover') - 1]).to eql ' '
     end
 
     it "should work for meta tags without content" do
@@ -278,7 +278,7 @@ describe PDFKit do
         </html>
       }
       pdfkit = PDFKit.new(body)
-      pdfkit.command[pdfkit.command.index('"toc"') + 1].should == '"-"'
+      expect(pdfkit.command[pdfkit.command.index('"toc"') + 1]).to == '"-"'
     end
 
     it "should put a toc-option right after toc" do
@@ -292,7 +292,7 @@ describe PDFKit do
         </html>
       }
       pdfkit = PDFKit.new(body)
-      pdfkit.command[pdfkit.command.index('"toc"') + 1].should == '"--xsl-style-sheet"'
+      expect(pdfkit.command[pdfkit.command.index('"toc"') + 1]).to == '"--xsl-style-sheet"'
     end
 
     it "should put cover before page and page options" do
@@ -305,7 +305,7 @@ describe PDFKit do
         </html>
       }
       pdfkit = PDFKit.new(body)
-      pdfkit.command[pdfkit.command.index('"cover"') + 2].should == '"-"'
+      expect(pdfkit.command[pdfkit.command.index('"cover"') + 2]).to == '"-"'
     end
 
     it "should work for meta tags without content" do
@@ -318,7 +318,7 @@ describe PDFKit do
         </html>
       }
       pdfkit = PDFKit.new(body)
-      pdfkit.command[pdfkit.command.index('"toc"') + 1][0..2].should == '"-"'
+      expect(pdfkit.command[pdfkit.command.index('"toc"') + 1][0..2]).to == '"-"'
     end
 
   end

--- a/spec/pdfkit_spec.rb
+++ b/spec/pdfkit_spec.rb
@@ -241,6 +241,33 @@ describe PDFKit do
       end
     end
 
+    it "should not prefix cover and toc meta tags" do
+      body = %{
+        <html>
+          <head>
+            <meta name="pdfkit-toc" content="Toc" />
+            <meta name="pdfkit-cover" content="some.html"/>
+          </head>
+        </html>
+      }
+      pdfkit = PDFKit.new(body)
+      pdfkit.command[pdfkit.command.index('"toc"') + 1].should == '"Toc"'
+      pdfkit.command[pdfkit.command.index('"cover"') + 1].should == '"some.html"'
+    end
+
+    it "should work for meta tags without content" do
+      body = %{
+        <html>
+          <head>
+            <meta name="pdfkit-toc" />
+            <meta name="pdfkit-orientation" content="Landscape" />
+          </head>
+        </html>
+      }
+      pdfkit = PDFKit.new(body)
+      pdfkit.command[pdfkit.command.index('"toc"') + 1].should == '"--orientation"'
+    end
+
   end
 
   context "#to_pdf" do

--- a/spec/pdfkit_spec.rb
+++ b/spec/pdfkit_spec.rb
@@ -251,8 +251,8 @@ describe PDFKit do
         </html>
       }
       pdfkit = PDFKit.new(body)
-      pdfkit.command[pdfkit.command.index('"toc"') + 1].should == '"Toc"'
-      pdfkit.command[pdfkit.command.index('"cover"') + 1].should == '"some.html"'
+      pdfkit.command[pdfkit.command.index('toc') - 1].should == ' '
+      pdfkit.command[pdfkit.command.index('cover') - 1].should == ' '
     end
 
     it "should work for meta tags without content" do

--- a/spec/pdfkit_spec.rb
+++ b/spec/pdfkit_spec.rb
@@ -265,7 +265,7 @@ describe PDFKit do
         </html>
       }
       pdfkit = PDFKit.new(body)
-      pdfkit.command[pdfkit.command.index('"toc"') + 1].should == '"--orientation"'
+      pdfkit.command[pdfkit.command.index('"toc"') + 1][0..2].should == '"--'
     end
 
   end

--- a/spec/pdfkit_spec.rb
+++ b/spec/pdfkit_spec.rb
@@ -259,13 +259,66 @@ describe PDFKit do
       body = %{
         <html>
           <head>
+            <meta name="pdfkit-default-header" />
+            <meta name="pdfkit-javascript-delay" content="20" />
+          </head>
+        </html>
+      }
+      pdfkit = PDFKit.new(body)
+      pdfkit.command[pdfkit.command.index('"--default-header"') + 1][0..2].should == '"--'
+    end
+
+    it "should put toc option just before the page and page options" do
+      body = %{
+        <html>
+          <head>
+            <meta name="pdfkit-toc" />
+            <meta name="pdfkit-javascript-delay" content="20" />
+          </head>
+        </html>
+      }
+      pdfkit = PDFKit.new(body)
+      pdfkit.command[pdfkit.command.index('"toc"') + 1].should == '"-"'
+    end
+
+    it "should put a toc-option right after toc" do
+      body = %{
+        <html>
+          <head>
+            <meta name="pdfkit-toc" />
+            <meta name="pdfkit-javascript-delay" content="20" />
+            <meta name="pdfkit-xsl-style-sheet" content="toc.xsl"/>
+          </head>
+        </html>
+      }
+      pdfkit = PDFKit.new(body)
+      pdfkit.command[pdfkit.command.index('"toc"') + 1].should == '"--xsl-style-sheet"'
+    end
+
+    it "should put cover before page and page options" do
+      body = %{
+        <html>
+          <head>
+            <meta name="pdfkit-cover" content="cover.html" />
+            <meta name="pdfkit-javascript-delay" content="20" />
+          </head>
+        </html>
+      }
+      pdfkit = PDFKit.new(body)
+      pdfkit.command[pdfkit.command.index('"cover"') + 2].should == '"-"'
+    end
+
+    it "should work for meta tags without content" do
+      body = %{
+        <html>
+          <head>
             <meta name="pdfkit-toc" />
             <meta name="pdfkit-orientation" content="Landscape" />
           </head>
         </html>
       }
       pdfkit = PDFKit.new(body)
-      pdfkit.command[pdfkit.command.index('"toc"') + 1][0..2].should == '"--'
+      pdfkit.command[pdfkit.command.index('"toc"') + 1][0..2].should == '"-"'
     end
 
   end

--- a/spec/pdfkit_spec.rb
+++ b/spec/pdfkit_spec.rb
@@ -265,7 +265,7 @@ describe PDFKit do
         </html>
       }
       pdfkit = PDFKit.new(body)
-      pdfkit.command[pdfkit.command.index('"--default-header"') + 1][0..2].should == '"--'
+      expect(pdfkit.command.include?('--default-header')).to be_truthy
     end
 
     it "should put toc option just before the page and page options" do


### PR DESCRIPTION
rebase of https://github.com/pdfkit/pdfkit/pull/158 on top of current master, and updates to make the options work.

Original PR notes -

Don't prefix them with --, and allow metatags without content.

Moved --quiet to first command, otherwise it conflicted with the toc option when setting it.

Sadly the order in which you set the meta tags is important when using toc, because wkhtmltopdf needs the toc options to be grouped, and after the toc tag.