### PR TITLE
Log benchmark of PDF generation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,25 @@ headers['PDFKit-save-pdf'] = 'path/to/saved.pdf'
 
 Will cause the .pdf to be saved to `path/to/saved.pdf` in addition to being sent back to the client.  If the path is not writable/non-existant the write will fail silently.  The `PDFKit-save-pdf` header is never sent back to the client.
 
+**Logging**
+
+The middleware supports logging a benchmark of how long the wkhtmltopdf command took by setting the PDFKit configuration option to a logger object or to `'rack.errors'` string to log to the Rack error output stream.
+
+For example:
+```ruby
+PDFKit.configure do |config|
+  config.benchmark_logger = 'rack.errors'
+end
+```
+
+or
+
+```ruby
+PDFKit.configure do |config|
+  config.benchmark_logger = Logger.new STDOUT
+end
+```
+
 ## Troubleshooting
 
 *  **Single thread issue:** In development environments it is common to run a

--- a/lib/pdfkit/configuration.rb
+++ b/lib/pdfkit/configuration.rb
@@ -1,11 +1,12 @@
 class PDFKit
   class Configuration
-    attr_accessor :meta_tag_prefix, :default_options, :root_url
+    attr_accessor :meta_tag_prefix, :default_options, :root_url, :benchmark_logger
     attr_writer :wkhtmltopdf, :verbose
 
     def initialize
       @verbose         = false
       @meta_tag_prefix = 'pdfkit-'
+      @benchmark_logger = nil
       @default_options = {
         :disable_smart_shrinking => false,
         :quiet => true,

--- a/lib/pdfkit/middleware.rb
+++ b/lib/pdfkit/middleware.rb
@@ -27,7 +27,14 @@ class PDFKit
           body = PDFKit.new(translate_paths(body, env), @options).to_pdf
         end
 
-        env['rack.errors'].write "Generated PDF for \"#{@request.path_info}\" in #{benchmark} seconds."
+        logger = PDFKit.configuration.benchmark_logger
+        unless logger.nil?
+          if logger == "rack.errors"
+            env["rack.errors"].write "Generated PDF for \"#{@request.path_info}\" in #{benchmark} seconds."
+          else
+            logger << "Generated PDF for \"#{@request.path_info}\" in #{benchmark} seconds."
+          end
+        end
 
         response = [body]
 

--- a/lib/pdfkit/middleware.rb
+++ b/lib/pdfkit/middleware.rb
@@ -1,3 +1,5 @@
+require 'benchmark'
+
 class PDFKit
 
   class Middleware
@@ -20,7 +22,13 @@ class PDFKit
       if rendering_pdf? && headers['Content-Type'] =~ /text\/html|application\/xhtml\+xml/
         body = response.respond_to?(:body) ? response.body : response.join
         body = body.join if body.is_a?(Array)
-        body = PDFKit.new(translate_paths(body, env), @options).to_pdf
+
+        benchmark = Benchmark.realtime do
+          body = PDFKit.new(translate_paths(body, env), @options).to_pdf
+        end
+
+        env['rack.errors'].write "Generated PDF for \"#{@request.path_info}\" in #{benchmark} seconds."
+
         response = [body]
 
         if headers['PDFKit-save-pdf']


### PR DESCRIPTION
A couple of notes here:
- Didn't know how to test this since I have no access in the internals of `Rack::Lint::ErrorWrapper` but it will itself test the API of the logger is correctly used.
- Is `require 'benchmark'` ok there or should it be in `lib/pdfkit.rb`?
- Some other middlewares accept a logger in initialize and use that when given instead of `rack.errors` but I was personally not interested in that and it didn't seem that much useful to bother.
