### PR TITLE
Fix specs when used with wkhtmltopdf 0.12.1

### DIFF
--- a/spec/pdfkit_spec.rb
+++ b/spec/pdfkit_spec.rb
@@ -333,7 +333,7 @@ describe PDFKit do
     end
 
     it "should generate PDF if there are missing assets" do
-      pdfkit = PDFKit.new("<html><body><img alt='' src='http://example.com/surely-it-doesnt-exist.gif' /></body></html>", ignore_load_errors: true)
+      pdfkit = PDFKit.new("<html><body><img alt='' src='http://example.com/surely-it-doesnt-exist.gif' /></body></html>")
       pdf = pdfkit.to_pdf
       expect(pdf[0...4]).to eq("%PDF") # PDF Signature at the beginning
     end


### PR DESCRIPTION
0.12.1 is the current version of wkhtmltopdf and it behaves differently than the 0.9.9.1 used when the specs were written. This patch gets the suite passing with that version.
