### PR TITLE
make command escaping work on windows

### DIFF
--- a/lib/pdfkit/pdfkit.rb
+++ b/lib/pdfkit/pdfkit.rb
@@ -43,7 +43,15 @@ class PDFKit
 
     args << (path || '-') # Write to file or stdout
 
-    [executable, args.shelljoin].join ' '
+    args = if (is_windows?)
+      # Windows reserved shell characters are: & | ( ) < > ^
+      # See http://technet.microsoft.com/en-us/library/cc723564.aspx#XSLTsection123121120120
+      args.map { |arg| arg.gsub(/([&|()<>^])/,'^\1') }.join(" ")
+    else
+      args.shelljoin
+    end
+
+    [executable, args].join ' '
   end
 
   def executable
@@ -78,6 +86,11 @@ class PDFKit
   def to_file(path)
     self.to_pdf(path)
     File.new(path)
+  end
+
+  def is_windows?
+    require 'rbconfig'
+    !(RbConfig::CONFIG['host_os'] =~ /mswin|mingw|cygwin/).nil?
   end
 
   protected
@@ -160,6 +173,7 @@ class PDFKit
       when Array
         value.flatten.collect{|x| x.to_s}
       else
+        return '\'' + value.to_s + '\'' if (is_windows? && value.to_s.index(' '))
         value.to_s
       end
     end

--- a/spec/pdfkit_spec.rb
+++ b/spec/pdfkit_spec.rb
@@ -243,6 +243,23 @@ describe PDFKit do
 
   end
 
+  context "command on windows" do
+
+    before do
+      allow_any_instance_of(PDFKit).to receive(:is_windows?).and_return(true)
+    end
+
+    it "escapes special windows characters" do
+      pdf = PDFKit.new('html', :title => 'hello(world)')
+      expect(pdf.command).to include 'hello^(world^)'
+    end
+
+    it "quotes spaces in options" do
+      pdf = PDFKit.new('html', :title => 'hello world')
+      expect(pdf.command).to include '--title \'hello world\''
+    end
+  end
+
   context "#to_pdf" do
     it "should not read the contents of the pdf when saving it as a file" do
       file_path = "/my/file/path.pdf"


### PR DESCRIPTION
Windows command escaping is rather different and alas, can't rely on shelljoin . It doesn't look like there's anything in stdlib to handle it either, hence the implementation inlined herein.