### PR TITLE
Xvfb support

### DIFF
--- a/lib/pdfkit/configuration.rb
+++ b/lib/pdfkit/configuration.rb
@@ -1,10 +1,11 @@
 class PDFKit
   class Configuration
     attr_accessor :meta_tag_prefix, :default_options, :root_url
-    attr_writer :verbose
+    attr_writer :use_xvfb, :verbose
 
     def initialize
       @verbose         = false
+      @use_xvfb        = false
       @meta_tag_prefix = 'pdfkit-'
       @default_options = {
         :disable_smart_shrinking => false,
@@ -35,6 +36,14 @@ class PDFKit
       end
     end
 
+    def executable
+      using_xvfb? ? "xvfb-run #{wkhtmltopdf}" : wkhtmltopdf
+    end
+
+    def using_xvfb?
+      @use_xvfb
+    end
+
     def quiet?
       !@verbose
     end
@@ -54,6 +63,7 @@ class PDFKit
   # @example
   #   PDFKit.configure do |config|
   #     config.wkhtmltopdf = '/usr/bin/wkhtmltopdf'
+  #     config.use_xvfb    = true
   #     config.verbose     = true
   #   end
 

--- a/lib/pdfkit/pdfkit.rb
+++ b/lib/pdfkit/pdfkit.rb
@@ -53,7 +53,7 @@ class PDFKit
   end
 
   def executable
-    PDFKit.configuration.wkhtmltopdf
+    PDFKit.configuration.executable
   end
 
   def to_pdf(path=nil)

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -12,6 +12,17 @@ describe PDFKit::Configuration do
     end
   end
 
+  describe "#executable" do
+    it "returns wkhtmltopdf by default" do
+      expect(subject.executable).to eql subject.wkhtmltopdf
+    end
+
+    it "uses xvfb-run wrapper when option of using xvfb is configured" do
+      expect(subject).to receive(:using_xvfb?).and_return(true)
+      expect(subject.executable).to include 'xvfb-run'
+    end
+  end
+
   describe "#default_options" do
     it "sets defaults for the command options" do
       expect(subject.default_options[:disable_smart_shrinking]).to eql false
@@ -50,6 +61,22 @@ describe PDFKit::Configuration do
     it "is configurable" do
       subject.meta_tag_prefix = 'aDifferentPrefix-'
       expect(subject.meta_tag_prefix).to eql 'aDifferentPrefix-'
+    end
+  end
+
+  describe "#using_xvfb?" do
+    it "can be configured to true" do
+      subject.use_xvfb = true
+      expect(subject.using_xvfb?).to eql true
+    end
+
+    it "defaults to false" do
+      expect(subject.using_xvfb?).to eql false
+    end
+
+    it "can be configured to false" do
+      subject.use_xvfb = false
+      expect(subject.using_xvfb?).to eql false
     end
   end
 

--- a/spec/pdfkit_spec.rb
+++ b/spec/pdfkit_spec.rb
@@ -384,6 +384,24 @@ describe PDFKit do
       end
     end
 
+    it "does not use xvfb-run wrapper by default" do
+      pdfkit = PDFKit.new('html')
+      expect(pdfkit.command).not_to include 'xvfb-run'
+    end
+
+    it "uses xvfb-run wrapper when option of using xvfb is configured" do
+      PDFKit.configure do |config|
+        config.use_xvfb = true
+      end
+
+      pdfkit = PDFKit.new('html')
+      expect(pdfkit.command).to include 'xvfb-run'
+
+      PDFKit.configure do |config|
+        config.use_xvfb = false
+      end
+    end
+
     context "on windows" do
       before do
         allow(PDFKit::OS).to receive(:host_is_windows?).and_return(true)


### PR DESCRIPTION
Introduces `xvfb` config option, which is false by default.
It changes executable to run in a `xvfb-run` wrapper.

/cc @sigmavirus24 
