### PR TITLE
Ensure regexp correctly matches relative root path and move caching flag

### DIFF
--- a/lib/pdfkit/middleware.rb
+++ b/lib/pdfkit/middleware.rb
@@ -7,12 +7,12 @@ class PDFKit
       @options    = options
       @conditions = conditions
       @render_pdf = false
+      @caching    = @conditions.delete(:caching) { false }
     end
 
     def call(env)
       @request    = Rack::Request.new(env)
       @render_pdf = false
-      @caching    = @conditions.delete(:caching) { false }
 
       set_request_to_render_as_pdf(env) if render_as_pdf?
       status, headers, response = @app.call(env)

--- a/lib/pdfkit/middleware.rb
+++ b/lib/pdfkit/middleware.rb
@@ -52,7 +52,7 @@ class PDFKit
     def translate_relative_paths(body, env)
       root = PDFKit.configuration.root_url || "#{env['rack.url_scheme']}://#{env['HTTP_HOST']}/"
       # Try out this regexp using rubular http://rubular.com/r/vmuGSkheuu
-      body.gsub(/(href|src)=(['"])\/([^\/]([^\"']*|[^"']*))['"]/, "\\1=\\2#{root}\\3\\2")
+      body.gsub(/(href|src)=(['"])\/([^\/"']([^\"']*|[^"']*))?['"]/, "\\1=\\2#{root}\\3\\2")
     end
 
     def translate_relative_protocols(body, env)

--- a/spec/middleware_spec.rb
+++ b/spec/middleware_spec.rb
@@ -343,6 +343,12 @@ describe PDFKit::Middleware do
       expect(body).to eq("<link href='http://fonts.googleapis.com/css?family=Open+Sans:400,600' rel='stylesheet' type='text/css'>")
     end
 
+    it "should correctly parse multiple tags where first one is root url" do
+      @body = %{<a href='/'><img src='/logo.jpg' ></a>}
+      body = @pdf.send :translate_paths, @body, @env
+      body.should == "<a href='http://example.com/'><img src='http://example.com/logo.jpg' ></a>"
+    end
+
     it "should return the body even if there are no valid substitutions found" do
       @body = "NO MATCH"
       body = @pdf.send :translate_paths, @body, @env


### PR DESCRIPTION
Previously if there was a tag with href='/' followed by another tag with a relative URL, the contents of the second tag would not be replaced with an absolute URL. Added a test for this edge case and tweaked the regexp to fix.

The second commit moves the caching flag into the initialize method so it's only set once. It was being deleted from the conditions instance var on the first run, then set to false for all subsequent runs. 