### PR TITLE
Provide debug option to view html used to generate pdf.

### DIFF
--- a/lib/pdfkit/pdfkit.rb
+++ b/lib/pdfkit/pdfkit.rb
@@ -25,6 +25,7 @@ class PDFKit
     @stylesheets = []
 
     @options = PDFKit.configuration.default_options.merge(options)
+    @dump_source = @options.delete(:dump_source)
     @options.delete(:quiet) if PDFKit.configuration.verbose?
     @options.merge! find_options_in_meta(url_file_or_html) unless source.url?
     @options = normalize_options(@options)
@@ -58,6 +59,10 @@ class PDFKit
 
   def to_pdf(path=nil)
     append_stylesheets
+
+    if @dump_source
+      File.open(@dump_source, 'w') { |fd| fd.write(@source.to_s) }
+    end
 
     invoke = command(path)
 


### PR DESCRIPTION
Provide a way for users to view the html, including stylesheets, that will be
used by wkhtmltopdf.

We needed this to figure out why our style was silly inside of pdfs.
