### PR TITLE
split error messages inside to_pdf(path)

### DIFF
--- a/lib/pdfkit/pdfkit.rb
+++ b/lib/pdfkit/pdfkit.rb
@@ -71,7 +71,8 @@ class PDFKit
 
     # $? is thread safe per
     # http://stackoverflow.com/questions/2164887/thread-safe-external-process-in-ruby-plus-checking-exitstatus
-    raise "command failed (exitstatus=#{$?.exitstatus}): #{invoke}" if empty_result?(path, result) or !successful?($?)
+    raise "command failed (exitstatus=#{$?.exitstatus}):#{invoke} [empty_result]" if empty_result?(path, result)
+    raise "command failed (exitstatus=#{$?.exitstatus}):#{invoke} [not_successful]" if !successful?($?)
     return result
   end
 


### PR DESCRIPTION
It would be cool to add some context to this `raise` message.
