### PR TITLE
Add Tests, SimpleCov and Fix Repeating Keys Bug

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,11 @@ source 'https://rubygems.org'
 
 group :test do
   gem 'activesupport', '~> 3.0'
+  gem 'simplecov', require: false
+end
+
+group :development, :test do
+  gem 'pry'
 end
 
 gemspec

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ kit = PDFKit.new(url, cookie: {cookie_name: :cookie_value})
 kit = PDFKit.new(url, [:cookie, :cookie_name1] => :cookie_val1, [:cookie, :cookie_name2] => :cookie_val2)
 ```
 ## Configuration
-If you're on Windows or you installed wkhtmltopdf by hand to a location other than `/usr/local/bin` you will need to tell PDFKit where the binary is. You can configure PDFKit like so:
+If you're on Windows or you would like to use a specific wkhtmltopdf you installed, you will need to tell PDFKit where the binary is. PDFKit will try to intelligently guess at the location of wkhtmltopdf by running the command `which wkhtmltopdf`. If you are on Windows, want to point PDFKit to a different binary, or are having trouble with getting PDFKit to find your binary, please manually configure the wkhtmltopdf location. You can configure PDFKit like so:
 ```ruby
 # config/initializers/pdfkit.rb
 PDFKit.configure do |config|

--- a/lib/pdfkit/configuration.rb
+++ b/lib/pdfkit/configuration.rb
@@ -19,7 +19,7 @@ class PDFKit
     end
 
     def wkhtmltopdf
-      @wkhtmltopdf ||= (defined?(Bundler::GemfileError) && File.exists?('Gemfile') ? `bundle exec which wkhtmltopdf` : `which wkhtmltopdf`).chomp
+      @wkhtmltopdf ||= (defined?(Bundler::GemfileError) && File.exists?('Gemfile') ? `bundle exec which wkhtmltopdf` : `which wkhtmltopdf`).strip
     end
 
     def quiet?

--- a/lib/pdfkit/pdfkit.rb
+++ b/lib/pdfkit/pdfkit.rb
@@ -133,8 +133,8 @@ class PDFKit
 
       # If the option is repeatable, attempt to normalize all values
       if REPEATABLE_OPTIONS.include? normalized_key
-        normalize_repeatable_value(value) do |normalized_key_piece, normalized_value|
-          normalized_options[[normalized_key, normalized_key_piece]] = normalized_value
+        normalize_repeatable_value(normalized_key, value) do |normalized_unique_key, normalized_value|
+          normalized_options[normalized_unique_key] = normalized_value
         end
       else # Otherwise, just normalize it like usual
         normalized_options[normalized_key] = normalize_value(value)
@@ -161,14 +161,14 @@ class PDFKit
     end
   end
 
-  def normalize_repeatable_value(value)
+  def normalize_repeatable_value(option_name, value)
     case value
     when Hash, Array
       value.each do |(key, val)|
-        yield [normalize_value(key), normalize_value(val)]
+        yield [[option_name, normalize_value(key)], normalize_value(val)]
       end
     else
-      [normalize_value(value), '']
+      yield [[option_name, normalize_value(value)], '']
     end
   end
 

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -1,0 +1,105 @@
+require 'spec_helper'
+
+describe PDFKit::Configuration do
+  subject { PDFKit::Configuration.new }
+  describe "#wkhtmltopdf" do
+    it "can be configured" do
+      subject.wkhtmltopdf = '/my/bin/wkhtmltopdf'
+      expect(subject.wkhtmltopdf).to eql '/my/bin/wkhtmltopdf'
+    end
+
+    # This test documents existing functionality. Feel free to fix.
+    it "can be poorly configured" do
+      subject.wkhtmltopdf = 1234
+      expect(subject.wkhtmltopdf).to eql 1234
+    end
+
+    context "when not explicitly configured" do
+      it "detects the existance of bundler" do
+        # Test assumes bundler is installed in your test environment
+        expect(subject).to receive(:`).with('bundle exec which wkhtmltopdf').and_return('c:\windows\path.exe')
+        subject.wkhtmltopdf
+      end
+
+      it "does not use Bundler if Bundler is not defined"
+
+      it "trims whitespace" do
+        allow(subject).to receive(:`).and_return(" /usr/local \n\n")
+        expect(subject.wkhtmltopdf).to eql '/usr/local'
+      end
+    end
+  end
+
+  describe "#default_options" do
+    it "sets defaults for the command options" do
+      expect(subject.default_options[:disable_smart_shrinking]).to eql false
+      expect(subject.default_options[:quiet]).to eql true
+      expect(subject.default_options[:page_size]).to eql 'Letter'
+      expect(subject.default_options[:margin_top]).to eql '0.75in'
+      expect(subject.default_options[:margin_bottom]).to eql '0.75in'
+      expect(subject.default_options[:margin_right]).to eql '0.75in'
+      expect(subject.default_options[:margin_left]).to eql '0.75in'
+      expect(subject.default_options[:encoding]).to eql 'UTF-8'
+    end
+
+    it "allows additional options to be configured" do
+      subject.default_options = { quiet: false, is_awesome: true }
+      expect(subject.default_options[:quiet]).to eql false
+      expect(subject.default_options[:is_awesome]).to eql true
+    end
+  end
+
+  describe "#root_url" do
+    it "has no default" do
+      expect(subject.root_url).to be_nil
+    end
+
+    it "is configurable" do
+      subject.root_url = 'https://arbitrary.base_url.for/middleware'
+      expect(subject.root_url).to eql 'https://arbitrary.base_url.for/middleware'
+    end
+  end
+
+  describe "#meta_tag_prefix" do
+    it "defaults to 'pdfkit-'" do
+      expect(subject.meta_tag_prefix).to eql 'pdfkit-'
+    end
+
+    it "is configurable" do
+      subject.meta_tag_prefix = 'aDifferentPrefix-'
+      expect(subject.meta_tag_prefix).to eql 'aDifferentPrefix-'
+    end
+  end
+
+  describe "#verbose?" do
+    it "can be configured to true" do
+      subject.verbose = true
+      expect(subject.verbose?).to eql true
+    end
+
+    it "defaults to false" do
+      expect(subject.verbose?).to eql false
+    end
+
+    it "can be configured to false" do
+      subject.verbose = false
+      expect(subject.verbose?).to eql false
+    end
+  end
+
+  describe "#quiet?" do
+    it "can be configured to true" do
+      subject.verbose = false
+      expect(subject.quiet?).to eql true
+    end
+
+    it "defaults to true" do
+      expect(subject.quiet?).to eql true
+    end
+
+    it "can be configured to false" do
+      subject.verbose = true
+      expect(subject.quiet?).to eql false
+    end
+  end
+end

--- a/spec/pdfkit_spec.rb
+++ b/spec/pdfkit_spec.rb
@@ -2,7 +2,8 @@
 require 'spec_helper'
 
 describe PDFKit do
-  context "initialization" do
+  describe "initialization" do
+    # Source
     it "should accept HTML as the source" do
       pdfkit = PDFKit.new('<h1>Oh Hai</h1>')
       expect(pdfkit.source).to be_html
@@ -22,36 +23,114 @@ describe PDFKit do
       expect(pdfkit.source.to_s).to eq(file_path)
     end
 
-    it "should parse the options into a cmd line friedly format" do
+    # Options
+    ## options keys
+    it "drops options without values" do
+      pdfkit = PDFKit.new('html', :page_size => nil)
+      expect(pdfkit.options).not_to have_key('--page-size')
+    end
+
+    it "transforms keys into command-line arguments" do
       pdfkit = PDFKit.new('html', :page_size => 'Letter')
       expect(pdfkit.options).to have_key('--page-size')
     end
 
-    it "should parse complex options into a cmd line friedly format" do
+    it "transforms complex keys into command-line arguments" do
       pdfkit = PDFKit.new('html', :replace => {'value' => 'something else'} )
       expect(pdfkit.options).to have_key('--replace')
     end
 
-    it "should provide default options" do
+    it "drops options with false or falsey values" do
+      pdfkit = PDFKit.new('html', disable_smart_shrinking: false)
+      expect(pdfkit.options).not_to have_key('--disable-smart-shrinking')
+    end
+
+    it "handles repeatable keys"
+
+    ## options values
+    it "parses string option values into strings" do
+      pdfkit = PDFKit.new('html', :page_size => 'Letter')
+      expect(pdfkit.options['--page-size']).to eql 'Letter'
+    end
+
+    it "drops option values of 'true'" do
+      pdfkit = PDFKit.new('html', disable_smart_shrinking: true)
+      expect(pdfkit.options).to have_key('--disable-smart-shrinking')
+      expect(pdfkit.options['--disable-smart-shrinking']).to be_nil
+    end
+
+    it "parses unknown value formats by transforming them into strings" do
+      pdfkit = PDFKit.new('html', image_dpi: 300)
+      expect(pdfkit.options['--image-dpi']).to eql '300'
+    end
+
+    it "parses hash option values into an array" do
+      pdfkit = PDFKit.new('html', :replace => {'value' => 'something else'} )
+      expect(pdfkit.options['--replace']).to eql ['value', 'something else']
+    end
+
+    it "flattens hash options into the key" do
+      pdfkit = PDFKit.new('html', :cookie => {:cookie_name1 => :cookie_val1, :cookie_name2 => :cookie_val2})
+      expect(pdfkit.options).not_to have_key('--cookie')
+      expect(pdfkit.options[['--cookie', 'cookie_name1']]).to eql 'cookie_val1'
+      expect(pdfkit.options[['--cookie', 'cookie_name2']]).to eql 'cookie_val2'
+    end
+
+    it "parses array option values into a string" do
+      pdfkit = PDFKit.new('html', :replace => ['value', 'something else'] )
+      expect(pdfkit.options['--replace']).to eql ['value', 'something else']
+    end
+
+    it "flattens array options" do
+      pdfkit = PDFKit.new('html', :cookie => [[:cookie_name1, :cookie_val1], [:cookie_name2, :cookie_val2]])
+      expect(pdfkit.options).not_to have_key('--cookie')
+      expect(pdfkit.options[['--cookie', 'cookie_name1']]).to eql 'cookie_val1'
+      expect(pdfkit.options[['--cookie', 'cookie_name2']]).to eql 'cookie_val2'
+    end
+
+    it "handles repeatable values"
+
+    ## default options
+    it "provides default options" do
       pdfkit = PDFKit.new('<h1>Oh Hai</h1>')
       ['--margin-top', '--margin-right', '--margin-bottom', '--margin-left'].each do |option|
         expect(pdfkit.options).to have_key(option)
       end
     end
 
-    it "should default to 'UTF-8' encoding" do
+    it "allows overriding default options" do
+      pdfkit = PDFKit.new('html', :page_size => 'A4')
+      expect(pdfkit.options['--page-size']).to eql 'A4'
+    end
+
+    it "defaults to 'UTF-8' encoding" do
       pdfkit = PDFKit.new('Captación')
       expect(pdfkit.options['--encoding']).to eq('UTF-8')
     end
 
-    it "should not have any stylesheedt by default" do
+    # Stylesheets
+    it "has no stylesheet by default" do
       pdfkit = PDFKit.new('<h1>Oh Hai</h1>')
       expect(pdfkit.stylesheets).to be_empty
     end
   end
 
-  context "command" do
-    it "should contstruct the correct command" do
+  describe "#options" do
+    # #options is an attr_reader, but it doesn't really matter. See these two examples:
+    it "cannot be externally overwritten entirely" do
+      pdfkit = PDFKit.new('html', :page_size => 'A4')
+      expect{ pdfkit.options = {} }.to raise_error(NoMethodError)
+    end
+
+    it "has attributes that are externally mutable" do
+      pdfkit = PDFKit.new('html', :page_size => 'A4')
+      pdfkit.options['--page-size'] = 'Letter'
+      expect(pdfkit.options['--page-size']).to eql 'Letter'
+    end
+  end
+
+  describe "#command" do
+    it "should construct the correct command" do
       pdfkit = PDFKit.new('html', :page_size => 'Letter', :toc_l1_font_size => 12, :replace => {'foo' => 'bar'})
       command = pdfkit.command
       expect(command).to include "wkhtmltopdf"
@@ -123,7 +202,7 @@ describe PDFKit do
       expect(pdfkit.command).to match /#{file_path} -$/
     end
 
-    it "should specify the path for the ouput if a apth is given" do
+    it "should specify the path for the ouput if a path is given" do
       file_path = "/path/to/output.pdf"
       pdfkit = PDFKit.new("html")
       expect(pdfkit.command(file_path)).to match /#{file_path}$/
@@ -223,7 +302,7 @@ describe PDFKit do
       expect(pdfkit.command).not_to include '--quiet'
     end
 
-    it "should use quiet option by defautl" do
+    it "should use quiet option by default" do
       pdfkit = PDFKit.new('html')
       expect(pdfkit.command).to include '--quiet'
     end
@@ -241,9 +320,22 @@ describe PDFKit do
       end
     end
 
+    it "should not use quiet option in verbose mode when option of quiet is configured" do
+      PDFKit.configure do |config|
+        config.verbose = true
+        config.default_options[:quiet] = true
+      end
+
+      pdfkit = PDFKit.new('html')
+      expect(pdfkit.command).not_to include '--quiet'
+
+      PDFKit.configure do |config|
+        config.verbose = false
+      end
+    end
   end
 
-  context "#to_pdf" do
+  describe "#to_pdf" do
     it "should not read the contents of the pdf when saving it as a file" do
       file_path = "/my/file/path.pdf"
       pdfkit = PDFKit.new('html', :page_size => 'Letter')
@@ -252,7 +344,7 @@ describe PDFKit do
       expect(mock_pdf).to receive(:puts)
       expect(mock_pdf).not_to receive(:gets) # do no read the contents when given a file path
       expect(mock_pdf).to receive(:close_write)
-      
+
 
       expect(IO).to receive(:popen) do |args, mode, &block|
         block.call(mock_pdf)
@@ -339,7 +431,7 @@ describe PDFKit do
     end
   end
 
-  context "#to_file" do
+  describe "#to_file" do
     before do
       @file_path = File.join(SPEC_ROOT,'fixtures','test.pdf')
       File.delete(@file_path) if File.exist?(@file_path)
@@ -360,7 +452,7 @@ describe PDFKit do
       file_path = File.join(SPEC_ROOT,'fixtures','example.html')
       pdfkit = PDFKit.new(File.new(file_path))
       pdf_data = pdfkit.to_pdf
-      file = pdfkit.to_file(@file_path)
+      pdfkit.to_file(@file_path)
       file_data = open(@file_path, 'rb') {|io| io.read }
       expect(pdf_data.size).to eq(file_data.size)
     end

--- a/spec/pdfkit_spec.rb
+++ b/spec/pdfkit_spec.rb
@@ -45,8 +45,6 @@ describe PDFKit do
       expect(pdfkit.options).not_to have_key('--disable-smart-shrinking')
     end
 
-    it "handles repeatable keys"
-
     ## options values
     it "parses string option values into strings" do
       pdfkit = PDFKit.new('html', :page_size => 'Letter')
@@ -88,7 +86,22 @@ describe PDFKit do
       expect(pdfkit.options[['--cookie', 'cookie_name2']]).to eql 'cookie_val2'
     end
 
-    it "handles repeatable values"
+    it "handles repeatable values which are strings" do
+      pdfkit = PDFKit.new('html', allow: 'http://myapp.com')
+      expect(pdfkit.options).to have_key ['--allow', 'http://myapp.com']
+    end
+
+    it "handles repeatable values which are hashes" do
+      pdfkit = PDFKit.new('html', allow: { 'http://myapp.com' => nil, 'http://google.com' => nil })
+      expect(pdfkit.options).to have_key ['--allow', 'http://myapp.com']
+      expect(pdfkit.options).to have_key ['--allow', 'http://google.com']
+    end
+
+    it "handles repeatable values which are arrays" do
+      pdfkit = PDFKit.new('html', allow: ['http://myapp.com', 'http://google.com'])
+      expect(pdfkit.options).to have_key ['--allow', 'http://myapp.com']
+      expect(pdfkit.options).to have_key ['--allow', 'http://google.com']
+    end
 
     ## default options
     it "provides default options" do

--- a/spec/source_spec.rb
+++ b/spec/source_spec.rb
@@ -1,18 +1,17 @@
 require 'spec_helper'
 
 describe PDFKit::Source do
-  
   describe "#url?" do
     it "should return true if passed a url like string" do
       source = PDFKit::Source.new('http://google.com')
       expect(source).to be_url
     end
-    
+
     it "should return false if passed a file" do
       source = PDFKit::Source.new(File.new(__FILE__))
       expect(source).not_to be_url
     end
-    
+
     it "should return false if passed HTML" do
       source = PDFKit::Source.new('<blink>Oh Hai!</blink>')
       expect(source).not_to be_url
@@ -23,52 +22,52 @@ describe PDFKit::Source do
       expect(source).not_to be_url
     end
   end
-  
+
   describe "#file?" do
     it "should return true if passed a file" do
       source = PDFKit::Source.new(::File.new(__FILE__))
       expect(source).to be_file
     end
-    
+
     it "should return false if passed a url like string" do
       source = PDFKit::Source.new('http://google.com')
       expect(source).not_to be_file
     end
-    
+
     it "should return false if passed HTML" do
       source = PDFKit::Source.new('<blink>Oh Hai!</blink>')
       expect(source).not_to be_file
     end
   end
-  
+
   describe "#html?" do
     it "should return true if passed HTML" do
       source = PDFKit::Source.new('<blink>Oh Hai!</blink>')
       expect(source).to be_html
     end
-    
+
     it "should return false if passed a file" do
       source = PDFKit::Source.new(::File.new(__FILE__))
       expect(source).not_to be_html
     end
-    
+
     it "should return false if passed a url like string" do
       source = PDFKit::Source.new('http://google.com')
       expect(source).not_to be_html
     end
   end
-  
+
   describe "#to_s" do
     it "should return the HTML if passed HTML" do
       source = PDFKit::Source.new('<blink>Oh Hai!</blink>')
       expect(source.to_s).to eq('<blink>Oh Hai!</blink>')
     end
-    
+
     it "should return a path if passed a file" do
       source = PDFKit::Source.new(::File.new(__FILE__))
       expect(source.to_s).to eq(__FILE__)
     end
-    
+
     it "should return the url if passed a url like string" do
       source = PDFKit::Source.new('http://google.com')
       expect(source.to_s).to eq('http://google.com')

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,9 @@ SPEC_ROOT = File.dirname(__FILE__)
 $LOAD_PATH.unshift(SPEC_ROOT)
 $LOAD_PATH.unshift(File.join(SPEC_ROOT, '..', 'lib'))
 require 'simplecov'
-SimpleCov.start
+SimpleCov.start do
+  add_filter "spec/"
+end
 
 require 'pdfkit'
 require 'rspec'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,9 @@
 SPEC_ROOT = File.dirname(__FILE__)
 $LOAD_PATH.unshift(SPEC_ROOT)
 $LOAD_PATH.unshift(File.join(SPEC_ROOT, '..', 'lib'))
+require 'simplecov'
+SimpleCov.start
+
 require 'pdfkit'
 require 'rspec'
 require 'mocha'


### PR DESCRIPTION
This PR adds test coverage for PDFKit::Configuration and PDFKit::PDFKit#new.

It also fixes a bug related to the handling on string values for repeatable options. 

Previous functionality:

```
$ pdfkit = PDFKit.new('html', allow: "http://google.com")
$ pdfkit.options.include?(['--allow', 'http://google.com'])
=> false
```

New functionality:
```
$ pdfkit = PDFKit.new('html', allow: "http://google.com")
$ pdfkit.options[['--allow', 'http://google.com']]
=> ''
$ pdfkit = PDFKit.new('html', allow: {"http://google.com" => nil, "http://myapp.com" => nil)
$ pdfkit.options[['--allow', 'http://google.com']]
=> ''
```

I believe this is the correct functionality.