### PR TITLE
cover and toc should not be prepended with -- when passed as options

### DIFF
--- a/lib/pdfkit/pdfkit.rb
+++ b/lib/pdfkit/pdfkit.rb
@@ -130,8 +130,8 @@ class PDFKit
       next if !value
 
       # The actual option for wkhtmltopdf
-      normalized_key = "#{normalize_arg key}"
-      normalized_key = "--#{normalized_key}" unless SPECIAL_OPTIONS.include?(key)
+      normalized_key = normalize_arg key
+      normalized_key = "--#{normalized_key}" unless SPECIAL_OPTIONS.include?(normalized_key)
 
       # If the option is repeatable, attempt to normalize all values
       if REPEATABLE_OPTIONS.include? normalized_key

--- a/lib/pdfkit/pdfkit.rb
+++ b/lib/pdfkit/pdfkit.rb
@@ -82,6 +82,7 @@ class PDFKit
   # Pulled from:
   # https://github.com/wkhtmltopdf/wkhtmltopdf/blob/ebf9b6cfc4c58a31349fb94c568b254fac37b3d3/README_WKHTMLTOIMAGE#L27
   REPEATABLE_OPTIONS = %w[--allow --cookie --custom-header --post --post-file --run-script]
+  SPECIAL_OPTIONS = %w[cover toc]
 
   def find_options_in_meta(content)
     # Read file if content is a File
@@ -129,7 +130,8 @@ class PDFKit
       next if !value
 
       # The actual option for wkhtmltopdf
-      normalized_key = "--#{normalize_arg key}"
+      normalized_key = "#{normalize_arg key}"
+      normalized_key = "--#{normalized_key}" unless SPECIAL_OPTIONS.include?(key)
 
       # If the option is repeatable, attempt to normalize all values
       if REPEATABLE_OPTIONS.include? normalized_key

--- a/spec/pdfkit_spec.rb
+++ b/spec/pdfkit_spec.rb
@@ -48,6 +48,16 @@ describe PDFKit do
       pdfkit = PDFKit.new('<h1>Oh Hai</h1>')
       expect(pdfkit.stylesheets).to be_empty
     end
+
+    it "should not prepend cover with --" do
+      pdfkit = PDFKit.new('html', "cover" => 'http://google.com')
+      expect(pdfkit.options).to have_key('cover')
+    end
+
+    it "should not prepend toc with --" do
+      pdfkit = PDFKit.new('html', 'toc' => '')
+      expect(pdfkit.options).to have_key('toc')
+    end
   end
 
   context "command" do
@@ -252,7 +262,7 @@ describe PDFKit do
       expect(mock_pdf).to receive(:puts)
       expect(mock_pdf).not_to receive(:gets) # do no read the contents when given a file path
       expect(mock_pdf).to receive(:close_write)
-      
+
 
       expect(IO).to receive(:popen) do |args, mode, &block|
         block.call(mock_pdf)

--- a/spec/pdfkit_spec.rb
+++ b/spec/pdfkit_spec.rb
@@ -58,6 +58,11 @@ describe PDFKit do
       pdfkit = PDFKit.new('html', 'toc' => '')
       expect(pdfkit.options).to have_key('toc')
     end
+
+    it "should handle special params passed as symbols" do
+      pdfkit = PDFKit.new('html', {toc: true})
+      expect(pdfkit.options).to have_key('toc')
+    end
   end
 
   context "command" do


### PR DESCRIPTION
other PR which references this problem breaks headers and footers. This simple change stops cover and toc from being prepended with -- when the options are normalized.