### PR TITLE
Add SimpleCov & Pry as development dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,11 @@ source 'https://rubygems.org'
 
 group :test do
   gem 'activesupport', '~> 3.0'
+  gem 'simplecov', require: false
+end
+
+group :development, :test do
+  gem 'pry'
 end
 
 gemspec

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,9 @@
 SPEC_ROOT = File.dirname(__FILE__)
 $LOAD_PATH.unshift(SPEC_ROOT)
 $LOAD_PATH.unshift(File.join(SPEC_ROOT, '..', 'lib'))
+require 'simplecov'
+SimpleCov.start
+
 require 'pdfkit'
 require 'rspec'
 require 'mocha'


### PR DESCRIPTION
I find these to be useful for developing and reviewing pull requests, but if there is any drawback to adding these, then let's not do it.