### PR TITLE
Fix bug with repeating keys with string values

### DIFF
--- a/lib/pdfkit/pdfkit.rb
+++ b/lib/pdfkit/pdfkit.rb
@@ -135,8 +135,8 @@ class PDFKit
 
       # If the option is repeatable, attempt to normalize all values
       if REPEATABLE_OPTIONS.include? normalized_key
-        normalize_repeatable_value(value) do |normalized_key_piece, normalized_value|
-          normalized_options[[normalized_key, normalized_key_piece]] = normalized_value
+        normalize_repeatable_value(normalized_key, value) do |normalized_unique_key, normalized_value|
+          normalized_options[normalized_unique_key] = normalized_value
         end
       else # Otherwise, just normalize it like usual
         normalized_options[normalized_key] = normalize_value(value)
@@ -163,14 +163,14 @@ class PDFKit
     end
   end
 
-  def normalize_repeatable_value(value)
+  def normalize_repeatable_value(option_name, value)
     case value
     when Hash, Array
       value.each do |(key, val)|
-        yield [normalize_value(key), normalize_value(val)]
+        yield [[option_name, normalize_value(key)], normalize_value(val)]
       end
     else
-      [normalize_value(value), '']
+      yield [[option_name, normalize_value(value)], '']
     end
   end
 

--- a/spec/pdfkit_spec.rb
+++ b/spec/pdfkit_spec.rb
@@ -45,8 +45,6 @@ describe PDFKit do
       expect(pdfkit.options).not_to have_key('--disable-smart-shrinking')
     end
 
-    it "handles repeatable keys"
-
     ## options values
     it "parses string option values into strings" do
       pdfkit = PDFKit.new('html', :page_size => 'Letter')
@@ -88,8 +86,6 @@ describe PDFKit do
       expect(pdfkit.options[['--cookie', 'cookie_name2']]).to eql 'cookie_val2'
     end
 
-    it "handles repeatable values"
-
     ## default options
     it "provides default options" do
       pdfkit = PDFKit.new('<h1>Oh Hai</h1>')
@@ -106,6 +102,23 @@ describe PDFKit do
     it "defaults to 'UTF-8' encoding" do
       pdfkit = PDFKit.new('Captación')
       expect(pdfkit.options['--encoding']).to eq('UTF-8')
+    end
+
+    it "handles repeatable values which are strings" do
+      pdfkit = PDFKit.new('html', allow: 'http://myapp.com')
+      expect(pdfkit.options).to have_key ['--allow', 'http://myapp.com']
+    end
+
+    it "handles repeatable values which are hashes" do
+      pdfkit = PDFKit.new('html', allow: { 'http://myapp.com' => nil, 'http://google.com' => nil })
+      expect(pdfkit.options).to have_key ['--allow', 'http://myapp.com']
+      expect(pdfkit.options).to have_key ['--allow', 'http://google.com']
+    end
+
+    it "handles repeatable values which are arrays" do
+      pdfkit = PDFKit.new('html', allow: ['http://myapp.com', 'http://google.com'])
+      expect(pdfkit.options).to have_key ['--allow', 'http://myapp.com']
+      expect(pdfkit.options).to have_key ['--allow', 'http://google.com']
     end
 
     # Stylesheets


### PR DESCRIPTION
This PR fixes a bug related to the handling on string values for repeatable options. 

Previous functionality:

```
$ pdfkit = PDFKit.new('html', allow: "http://google.com")
$ pdfkit.options.include?(['--allow', 'http://google.com'])
=> false
```

New functionality:
```
$ pdfkit = PDFKit.new('html', allow: "http://google.com")
$ pdfkit.options[['--allow', 'http://google.com']]
=> ''
$ pdfkit = PDFKit.new('html', allow: {"http://google.com" => nil, "http://myapp.com" => nil)
$ pdfkit.options[['--allow', 'http://google.com']]
=> ''
```

I believe this is the correct functionality.