### PR TITLE
Add tests for PDFKit::Configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ kit = PDFKit.new(url, cookie: {cookie_name: :cookie_value})
 kit = PDFKit.new(url, [:cookie, :cookie_name1] => :cookie_val1, [:cookie, :cookie_name2] => :cookie_val2)
 ```
 ## Configuration
-If you're on Windows or you installed wkhtmltopdf by hand to a location other than `/usr/local/bin` you will need to tell PDFKit where the binary is. You can configure PDFKit like so:
+If you're on Windows or you would like to use a specific wkhtmltopdf you installed, you will need to tell PDFKit where the binary is. PDFKit will try to intelligently guess at the location of wkhtmltopdf by running the command `which wkhtmltopdf`. If you are on Windows, want to point PDFKit to a different binary, or are having trouble with getting PDFKit to find your binary, please manually configure the wkhtmltopdf location. You can configure PDFKit like so:
 ```ruby
 # config/initializers/pdfkit.rb
 PDFKit.configure do |config|

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -1,0 +1,98 @@
+require 'spec_helper'
+
+describe PDFKit::Configuration do
+  subject { PDFKit::Configuration.new }
+  describe "#wkhtmltopdf" do
+    it "can be configured" do
+      subject.wkhtmltopdf = '/my/bin/wkhtmltopdf'
+      expect(subject.wkhtmltopdf).to eql '/my/bin/wkhtmltopdf'
+    end
+
+    # This test documents existing functionality. Feel free to fix.
+    it "can be poorly configured" do
+      subject.wkhtmltopdf = 1234
+      expect(subject.wkhtmltopdf).to eql 1234
+    end
+
+    context "when not explicitly configured" do
+      it "detects the existance of bundler" do
+        # Test assumes bundler is installed in your test environment
+        expect(subject).to receive(:`).with('bundle exec which wkhtmltopdf').and_return('c:\windows\path.exe')
+        subject.wkhtmltopdf
+      end
+    end
+  end
+
+  describe "#default_options" do
+    it "sets defaults for the command options" do
+      expect(subject.default_options[:disable_smart_shrinking]).to eql false
+      expect(subject.default_options[:quiet]).to eql true
+      expect(subject.default_options[:page_size]).to eql 'Letter'
+      expect(subject.default_options[:margin_top]).to eql '0.75in'
+      expect(subject.default_options[:margin_bottom]).to eql '0.75in'
+      expect(subject.default_options[:margin_right]).to eql '0.75in'
+      expect(subject.default_options[:margin_left]).to eql '0.75in'
+      expect(subject.default_options[:encoding]).to eql 'UTF-8'
+    end
+
+    it "allows additional options to be configured" do
+      subject.default_options = { quiet: false, is_awesome: true }
+      expect(subject.default_options[:quiet]).to eql false
+      expect(subject.default_options[:is_awesome]).to eql true
+    end
+  end
+
+  describe "#root_url" do
+    it "has no default" do
+      expect(subject.root_url).to be_nil
+    end
+
+    it "is configurable" do
+      subject.root_url = 'https://arbitrary.base_url.for/middleware'
+      expect(subject.root_url).to eql 'https://arbitrary.base_url.for/middleware'
+    end
+  end
+
+  describe "#meta_tag_prefix" do
+    it "defaults to 'pdfkit-'" do
+      expect(subject.meta_tag_prefix).to eql 'pdfkit-'
+    end
+
+    it "is configurable" do
+      subject.meta_tag_prefix = 'aDifferentPrefix-'
+      expect(subject.meta_tag_prefix).to eql 'aDifferentPrefix-'
+    end
+  end
+
+  describe "#verbose?" do
+    it "can be configured to true" do
+      subject.verbose = true
+      expect(subject.verbose?).to eql true
+    end
+
+    it "defaults to false" do
+      expect(subject.verbose?).to eql false
+    end
+
+    it "can be configured to false" do
+      subject.verbose = false
+      expect(subject.verbose?).to eql false
+    end
+  end
+
+  describe "#quiet?" do
+    it "can be configured to true" do
+      subject.verbose = false
+      expect(subject.quiet?).to eql true
+    end
+
+    it "defaults to true" do
+      expect(subject.quiet?).to eql true
+    end
+
+    it "can be configured to false" do
+      subject.verbose = true
+      expect(subject.quiet?).to eql false
+    end
+  end
+end


### PR DESCRIPTION
This class was previously implicitly tested through `spec/pdfkit_spec.rb`

Also, updated documentation to reflect what our code really does when detecting the wkhtmltopdf command. 