### PR TITLE
Do not shellescape URLs since it borks params 

### DIFF
--- a/lib/pdfkit/pdfkit.rb
+++ b/lib/pdfkit/pdfkit.rb
@@ -34,17 +34,16 @@ class PDFKit
 
   def command(path = nil)
     args = @options.to_a.flatten.compact
+    shell_escaped_command = [executable, shell_escape_for_os(args)].join ' '
 
-    if @source.html?
-      args << '-' # Get HTML from stdin
-    else
-      args << @source.to_s
-    end
+    # In order to allow for URL parameters (e.g. https://www.google.com/search?q=pdfkit) we do
+    # not escape the source. The user is responsible for ensuring that no vulnerabilities exist
+    # in the source. Please see https://github.com/pdfkit/pdfkit/issues/164.
+    # HTML source will come from stdin
+    input_for_command = @source.html? ? '-' : @source.to_s
+    output_for_command = path ? Shellwords.shellescape(path) : '-'
 
-    args << (path || '-') # Write to file or stdout
-
-
-    [executable, shell_escape_for_os(args)].join ' '
+    "#{shell_escaped_command} #{input_for_command} #{output_for_command}"
   end
 
   def executable

--- a/lib/pdfkit/pdfkit.rb
+++ b/lib/pdfkit/pdfkit.rb
@@ -39,8 +39,7 @@ class PDFKit
     # In order to allow for URL parameters (e.g. https://www.google.com/search?q=pdfkit) we do
     # not escape the source. The user is responsible for ensuring that no vulnerabilities exist
     # in the source. Please see https://github.com/pdfkit/pdfkit/issues/164.
-    # HTML source will come from stdin
-    input_for_command = @source.html? ? '-' : @source.to_s
+    input_for_command = @source.to_input_for_command
     output_for_command = path ? Shellwords.shellescape(path) : '-'
 
     "#{shell_escaped_command} #{input_for_command} #{output_for_command}"

--- a/lib/pdfkit/source.rb
+++ b/lib/pdfkit/source.rb
@@ -1,8 +1,9 @@
 class PDFKit
   class Source
+    SOURCE_FROM_STDIN = '-'
+
     def initialize(url_file_or_html)
       @source = url_file_or_html
-      URI(url_file_or_html) if url? # Raise if invalid URL to prevent bash shell attacks
     end
 
     def url?
@@ -15,6 +16,16 @@ class PDFKit
 
     def html?
       !(url? || file?)
+    end
+
+    def to_input_for_command
+      if file?
+        @source.path
+      elsif url?
+        URI::escape(@source)
+      else
+        SOURCE_FROM_STDIN
+      end
     end
 
     def to_s

--- a/lib/pdfkit/source.rb
+++ b/lib/pdfkit/source.rb
@@ -35,12 +35,10 @@ class PDFKit
     private
 
     def shell_safe_url
-      return unless url?
       url_needs_escaping? ? URI::escape(@source) : @source
     end
 
     def url_needs_escaping?
-      return unless url?
       URI::decode(@source) == @source
     end
   end

--- a/lib/pdfkit/source.rb
+++ b/lib/pdfkit/source.rb
@@ -22,7 +22,7 @@ class PDFKit
       if file?
         @source.path
       elsif url?
-        shell_safe_url
+        %{"#{shell_safe_url}"}
       else
         SOURCE_FROM_STDIN
       end

--- a/lib/pdfkit/source.rb
+++ b/lib/pdfkit/source.rb
@@ -2,20 +2,21 @@ class PDFKit
   class Source
     def initialize(url_file_or_html)
       @source = url_file_or_html
+      URI(url_file_or_html) if url? # Raise if invalid URL to prevent bash shell attacks
     end
-    
+
     def url?
       @source.is_a?(String) && @source.match(/\Ahttp/)
     end
-    
+
     def file?
       @source.kind_of?(File)
     end
-    
+
     def html?
       !(url? || file?)
     end
-    
+
     def to_s
       file? ? @source.path : @source
     end

--- a/lib/pdfkit/source.rb
+++ b/lib/pdfkit/source.rb
@@ -7,22 +7,22 @@ class PDFKit
     end
 
     def url?
-      @source.is_a?(String) && @source.match(/\Ahttp/)
+      @is_url ||= @source.is_a?(String) && @source.match(/\Ahttp/)
     end
 
     def file?
-      @source.kind_of?(File)
+      @is_file ||= @source.kind_of?(File)
     end
 
     def html?
-      !(url? || file?)
+      @is_html ||= !(url? || file?)
     end
 
     def to_input_for_command
       if file?
         @source.path
       elsif url?
-        URI::escape(@source)
+        shell_safe_url
       else
         SOURCE_FROM_STDIN
       end
@@ -30,6 +30,18 @@ class PDFKit
 
     def to_s
       file? ? @source.path : @source
+    end
+
+    private
+
+    def shell_safe_url
+      return unless url?
+      url_needs_escaping? ? URI::escape(@source) : @source
+    end
+
+    def url_needs_escaping?
+      return unless url?
+      URI::decode(@source) == @source
     end
   end
 end

--- a/spec/pdfkit_spec.rb
+++ b/spec/pdfkit_spec.rb
@@ -186,8 +186,13 @@ describe PDFKit do
 
     it "does not shell escape source URLs" do
       pdfkit = PDFKit.new('https://www.google.com/search?q=pdfkit')
-      # Shelljoin results in https://www.google.com/search\\?q\\=pdfkit
       expect(pdfkit.command).to include "https://www.google.com/search?q=pdfkit"
+    end
+
+    it "formats source for the command" do
+      pdfkit = PDFKit.new('https://www.google.com/search?q=pdfkit')
+      expect(pdfkit.source).to receive(:to_input_for_command)
+      pdfkit.command
     end
 
     it "sets up multiple cookies when passed multiple cookies" do

--- a/spec/pdfkit_spec.rb
+++ b/spec/pdfkit_spec.rb
@@ -178,6 +178,18 @@ describe PDFKit do
       expect(command).to include "--cookie cookie_name cookie_value"
     end
 
+    it "does not break Windows paths" do
+      pdfkit = PDFKit.new('html')
+      allow(PDFKit.configuration).to receive(:wkhtmltopdf).and_return 'c:/Program Files/wkhtmltopdf/wkhtmltopdf.exe'
+      expect(pdfkit.command).not_to include('Program\ Files')
+    end
+
+    it "does not shell escape source URLs" do
+      pdfkit = PDFKit.new('https://www.google.com/search?q=pdfkit')
+      # Shelljoin results in https://www.google.com/search\\?q\\=pdfkit
+      expect(pdfkit.command).to include "https://www.google.com/search?q=pdfkit"
+    end
+
     it "sets up multiple cookies when passed multiple cookies" do
       pdfkit = PDFKit.new('html', :cookie => {:cookie_name1 => :cookie_val1, :cookie_name2 => :cookie_val2})
       command = pdfkit.command

--- a/spec/pdfkit_spec.rb
+++ b/spec/pdfkit_spec.rb
@@ -237,7 +237,7 @@ describe PDFKit do
 
     it "specifies the URL to the source if it is a url" do
       pdfkit = PDFKit.new('http://google.com')
-      expect(pdfkit.command).to match /http:\/\/google.com -$/
+      expect(pdfkit.command).to match /"http:\/\/google.com" -$/
     end
 
     it "does not break Windows paths" do
@@ -492,6 +492,12 @@ describe PDFKit do
 
     it "generates a PDF if there are missing assets" do
       pdfkit = PDFKit.new("<html><body><img alt='' src='http://example.com/surely-it-doesnt-exist.gif' /></body></html>")
+      pdf = pdfkit.to_pdf
+      expect(pdf[0...4]).to eq("%PDF") # PDF Signature at the beginning
+    end
+
+    it "can handle ampersands in URLs" do
+      pdfkit = PDFKit.new('https://www.google.com/search?q=pdfkit&sort=ASC')
       pdf = pdfkit.to_pdf
       expect(pdf[0...4]).to eq("%PDF") # PDF Signature at the beginning
     end

--- a/spec/source_spec.rb
+++ b/spec/source_spec.rb
@@ -63,6 +63,11 @@ describe PDFKit::Source do
       expect(source.to_input_for_command).to eq "https://www.google.com/search?q='cat%3Cdev/zero%3E/dev/null'"
     end
 
+    it "does not URI escape previously escaped source URLs" do
+      source = PDFKit::Source.new("https://www.google.com/search?q='cat%3Cdev/zero%3E/dev/null'")
+      expect(source.to_input_for_command).to eq "https://www.google.com/search?q='cat%3Cdev/zero%3E/dev/null'"
+    end
+
     it "returns a '-' for HTML strings to indicate that we send that content through STDIN" do
       source = PDFKit::Source.new('<blink>Oh Hai!</blink>')
       expect(source.to_input_for_command).to eq '-'

--- a/spec/source_spec.rb
+++ b/spec/source_spec.rb
@@ -1,12 +1,6 @@
 require 'spec_helper'
 
 describe PDFKit::Source do
-  describe "#new" do
-    it "protects against shell attacks in URLs" do
-      expect{ PDFKit::Source.new('https://google.com/search?q=pdfkit; do_something # --args') }.to raise_error URI::InvalidURIError
-    end
-  end
-
   describe "#url?" do
     it "returns true if passed a url like string" do
       source = PDFKit::Source.new('http://google.com')
@@ -60,6 +54,23 @@ describe PDFKit::Source do
     it "returns false if passed a url like string" do
       source = PDFKit::Source.new('http://google.com')
       expect(source).not_to be_html
+    end
+  end
+
+  describe "#to_input_for_command" do
+    it "URI escapes source URLs" do
+      source = PDFKit::Source.new("https://www.google.com/search?q='cat<dev/zero>/dev/null'")
+      expect(source.to_input_for_command).to eq "https://www.google.com/search?q='cat%3Cdev/zero%3E/dev/null'"
+    end
+
+    it "returns a '-' for HTML strings to indicate that we send that content through STDIN" do
+      source = PDFKit::Source.new('<blink>Oh Hai!</blink>')
+      expect(source.to_input_for_command).to eq '-'
+    end
+
+    it "returns the file path for file sources" do
+      source = PDFKit::Source.new(::File.new(__FILE__))
+      expect(source.to_input_for_command).to match 'spec/source_spec.rb'
     end
   end
 

--- a/spec/source_spec.rb
+++ b/spec/source_spec.rb
@@ -1,6 +1,12 @@
 require 'spec_helper'
 
 describe PDFKit::Source do
+  describe "#new" do
+    it "protects against shell attacks in URLs" do
+      expect{ PDFKit::Source.new('https://google.com/search?q=pdfkit; do_something # --args') }.to raise_error URI::InvalidURIError
+    end
+  end
+
   describe "#url?" do
     it "returns true if passed a url like string" do
       source = PDFKit::Source.new('http://google.com')

--- a/spec/source_spec.rb
+++ b/spec/source_spec.rb
@@ -58,14 +58,14 @@ describe PDFKit::Source do
   end
 
   describe "#to_input_for_command" do
-    it "URI escapes source URLs" do
+    it "URI escapes source URLs and encloses them in quotes to accomodate ampersands" do
       source = PDFKit::Source.new("https://www.google.com/search?q='cat<dev/zero>/dev/null'")
-      expect(source.to_input_for_command).to eq "https://www.google.com/search?q='cat%3Cdev/zero%3E/dev/null'"
+      expect(source.to_input_for_command).to eq "\"https://www.google.com/search?q='cat%3Cdev/zero%3E/dev/null'\""
     end
 
     it "does not URI escape previously escaped source URLs" do
       source = PDFKit::Source.new("https://www.google.com/search?q='cat%3Cdev/zero%3E/dev/null'")
-      expect(source.to_input_for_command).to eq "https://www.google.com/search?q='cat%3Cdev/zero%3E/dev/null'"
+      expect(source.to_input_for_command).to eq "\"https://www.google.com/search?q='cat%3Cdev/zero%3E/dev/null'\""
     end
 
     it "returns a '-' for HTML strings to indicate that we send that content through STDIN" do


### PR DESCRIPTION
Fixes #166

Current Functionality (master):

```
>> PDFKit.new('https://www.google.com/search?q=pdfkit').command
wkhtmltopdf ... https://www.google.com/search\\?q\\=pdfkit
```

New Functionality (this PR):

```
>> PDFKit.new('https://www.google.com/search?q=pdfkit').command
wkhtmltopdf ... https://www.google.com/search?q=pdfkit
```

To accomplish this, this PR walks back some security measures implemented in #164.
* We no longer escape URLs
* We no longer escape HTML coming through middleware.

I don't know enough about bash exploits, so forgive the poor examples below.

This would impact those using PDFKit who allow raw user input in the URL (e.g. `www.mysite.com/echo /etc/passwd`) or in the HTML (e.g. `"<p>Your PDF Content: echo /etc/passwd</p>"` ).

On the other hand, I think we need to support query parameters. So, unless someone sees a better this solution, I'd say let's fix this.