### PR TITLE
Accept stylesheets via URL

### DIFF
--- a/lib/pdfkit/pdfkit.rb
+++ b/lib/pdfkit/pdfkit.rb
@@ -1,5 +1,6 @@
 require 'shellwords'
 require 'rbconfig'
+require 'open-uri'
 
 class PDFKit
   class NoExecutableError < StandardError
@@ -108,7 +109,7 @@ class PDFKit
   end
 
   def style_tag_for(stylesheet)
-    "<style>#{File.read(stylesheet)}</style>"
+    "<style>#{open(stylesheet).read}</style>"
   end
 
   def append_stylesheets


### PR DESCRIPTION
By using Ruby's open-uri library, we made it possible to also use URL as a source for stylesheets. Therefore the Rails Assets Pipeline will work 

kit = PDFKit.new(html)
kit.stylesheets << ActionController::Base.helpers.asset_path('example.css')
