### PR TITLE
Honor `root_url` in core

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,22 @@ PDFKit.new('<html><head><meta name="pdfkit-page_size" content="Letter"')
 PDFKit.new('<html><head><meta name="pdfkit-cookie cookie_name1" content="cookie_value1"')
 PDFKit.new('<html><head><meta name="pdfkit-cookie cookie_name2" content="cookie_value2"')
 ```
+
+### Resolving relative URLs and protocols
+
+If the source HTML has relative URLs (`/images/cat.png`) or
+[protocols](https://en.wikipedia.org/wiki/Uniform_Resource_Locator#prurl)
+(`//example.com/site.css`) that need to be resolved, you can pass `:root_url`
+and `:protocol` options to PDFKit:
+
+```ruby
+PDFKit.new(html, root_url: 'http://mysite.com/').to_file
+# or:
+PDFKit.new(html, protocol: 'https').to_file
+```
+
 ### Using cookies in scraping
-If you want to pass a cookie to cookie to pdfkit to scrape a website, you can 
+If you want to pass a cookie to cookie to pdfkit to scrape a website, you can
 pass it in a hash:
 ```ruby
 kit = PDFKit.new(url, cookie: {cookie_name: :cookie_value})
@@ -62,6 +76,7 @@ PDFKit.configure do |config|
   }
   # Use only if your external hostname is unavailable on the server.
   config.root_url = "http://localhost"
+  config.protocol = 'http'
   config.verbose = false
 end
 ```
@@ -127,8 +142,8 @@ Will cause the .pdf to be saved to `path/to/saved.pdf` in addition to being sent
    like Passenger or try to embed your resources within your HTML to
    avoid extra HTTP requests.
    
-   Example solution (rails / bundler), add unicorn to the development 
-   group in your Gemfile `gem 'unicorn'` then run `bundle`. Next, add a 
+   Example solution (rails / bundler), add unicorn to the development
+   group in your Gemfile `gem 'unicorn'` then run `bundle`. Next, add a
    file `config/unicorn.conf` with
    
         worker_processes 3
@@ -146,7 +161,7 @@ Will cause the .pdf to be saved to `path/to/saved.pdf` in addition to being sent
    asset host.
 
 *  **Mangled output in the browser:** Be sure that your HTTP response
-   headers specify "Content-Type: application/pdf" 
+   headers specify "Content-Type: application/pdf"
 
 ## Note on Patches/Pull Requests
 

--- a/lib/pdfkit.rb
+++ b/lib/pdfkit.rb
@@ -1,6 +1,7 @@
 require 'pdfkit/source'
 require 'pdfkit/pdfkit'
 require 'pdfkit/middleware'
+require 'pdfkit/html_preprocessor'
 require 'pdfkit/os'
 require 'pdfkit/configuration'
 require 'pdfkit/wkhtmltopdf'

--- a/lib/pdfkit/html_preprocessor.rb
+++ b/lib/pdfkit/html_preprocessor.rb
@@ -1,0 +1,23 @@
+class PDFKit
+  module HTMLPreprocessor
+
+    # Change relative paths to absolute, and relative protocols to absolute protocols
+    def self.process(html, root_url, protocol)
+      html = translate_relative_paths(html, root_url) if root_url
+      html = translate_relative_protocols(html, protocol) if protocol
+      html
+    end
+
+    private
+
+    def self.translate_relative_paths(html, root_url)
+      # Try out this regexp using rubular http://rubular.com/r/hiAxBNX7KE
+      html.gsub(/(href|src)=(['"])\/([^\/"']([^\"']*|[^"']*))?['"]/, "\\1=\\2#{root_url}\\3\\2")
+    end
+
+    def self.translate_relative_protocols(body, protocol)
+      # Try out this regexp using rubular http://rubular.com/r/0Ohk0wFYxV
+      body.gsub(/(href|src)=(['"])\/\/([^\"']*|[^"']*)['"]/, "\\1=\\2#{protocol}://\\3\\2")
+    end
+  end
+end

--- a/lib/pdfkit/middleware.rb
+++ b/lib/pdfkit/middleware.rb
@@ -18,7 +18,11 @@ class PDFKit
       if rendering_pdf? && headers['Content-Type'] =~ /text\/html|application\/xhtml\+xml/
         body = response.respond_to?(:body) ? response.body : response.join
         body = body.join if body.is_a?(Array)
-        body = PDFKit.new(translate_paths(body, env), @options).to_pdf
+
+        root_url = root_url(env)
+        protocol = protocol(env)
+        options = @options.merge(root_url: root_url, protocol: protocol)
+        body = PDFKit.new(body, options).to_pdf
         response = [body]
 
         if headers['PDFKit-save-pdf']
@@ -41,22 +45,12 @@ class PDFKit
 
     private
 
-    # Change relative paths to absolute, and relative protocols to absolute protocols
-    def translate_paths(body, env)
-      body = translate_relative_paths(body, env)
-      translate_relative_protocols(body, env)
+    def root_url(env)
+      PDFKit.configuration.root_url || "#{env['rack.url_scheme']}://#{env['HTTP_HOST']}/"
     end
 
-    def translate_relative_paths(body, env)
-      root = PDFKit.configuration.root_url || "#{env['rack.url_scheme']}://#{env['HTTP_HOST']}/"
-      # Try out this regexp using rubular http://rubular.com/r/hiAxBNX7KE
-      body.gsub(/(href|src)=(['"])\/([^\/"']([^\"']*|[^"']*))?['"]/, "\\1=\\2#{root}\\3\\2")
-    end
-
-    def translate_relative_protocols(body, env)
-      protocol = "#{env['rack.url_scheme']}://"
-      # Try out this regexp using rubular http://rubular.com/r/0Ohk0wFYxV
-      body.gsub(/(href|src)=(['"])\/\/([^\"']*|[^"']*)['"]/, "\\1=\\2#{protocol}\\3\\2")
+    def protocol(env)
+      env['rack.url_scheme']
     end
 
     def rendering_pdf?

--- a/spec/html_preprocessor_spec.rb
+++ b/spec/html_preprocessor_spec.rb
@@ -1,0 +1,69 @@
+require 'spec_helper'
+
+describe PDFKit::HTMLPreprocessor do
+  describe "#process" do
+    let(:preprocessor) { PDFKit::HTMLPreprocessor }
+    let(:root_url) { 'http://example.com/' }  # This mirrors Middleware#root_url's response
+    let(:protocol) { 'http' }
+
+    it "correctly parses host-relative url with single quotes" do
+      original_body = %{<html><head><link href='/stylesheets/application.css' media='screen' rel='stylesheet' type='text/css' /></head><body><img alt='test' src="/test.png" /></body></html>}
+      body = preprocessor.process original_body, root_url, protocol
+      expect(body).to eq("<html><head><link href='http://example.com/stylesheets/application.css' media='screen' rel='stylesheet' type='text/css' /></head><body><img alt='test' src=\"http://example.com/test.png\" /></body></html>")
+    end
+
+    it "correctly parses host-relative url with double quotes" do
+      original_body = %{<link href="/stylesheets/application.css" media="screen" rel="stylesheet" type="text/css" />}
+      body = preprocessor.process original_body, root_url, protocol
+      expect(body).to eq("<link href=\"http://example.com/stylesheets/application.css\" media=\"screen\" rel=\"stylesheet\" type=\"text/css\" />")
+    end
+
+    it "correctly parses protocol-relative url with single quotes" do
+      original_body = %{<link href='//fonts.googleapis.com/css?family=Open+Sans:400,600' rel='stylesheet' type='text/css'>}
+      body = preprocessor.process original_body, root_url, protocol
+      expect(body).to eq("<link href='http://fonts.googleapis.com/css?family=Open+Sans:400,600' rel='stylesheet' type='text/css'>")
+    end
+
+    it "correctly parses protocol-relative url with double quotes" do
+      original_body = %{<link href="//fonts.googleapis.com/css?family=Open+Sans:400,600" rel='stylesheet' type='text/css'>}
+      body = preprocessor.process original_body, root_url, protocol
+      expect(body).to eq("<link href=\"http://fonts.googleapis.com/css?family=Open+Sans:400,600\" rel='stylesheet' type='text/css'>")
+    end
+
+    it "correctly parses multiple tags where first one is root url" do
+      original_body = %{<a href='/'><img src='/logo.jpg' ></a>}
+      body = preprocessor.process original_body, root_url, protocol
+      expect(body).to eq "<a href='http://example.com/'><img src='http://example.com/logo.jpg' ></a>"
+    end
+
+    it "returns the body even if there are no valid substitutions found" do
+      original_body = "NO MATCH"
+      body = preprocessor.process original_body, root_url, protocol
+      expect(body).to eq("NO MATCH")
+    end
+
+    context 'when root_url is nil' do
+      it "returns the body safely, without interpolating" do
+        original_body = %{<link href='//fonts.googleapis.com/css?family=Open+Sans:400,600' rel='stylesheet' type='text/css'><a href='/'><img src='/logo.jpg'></a>}
+        body = preprocessor.process original_body, nil, protocol
+        expect(body).to eq(%{<link href='http://fonts.googleapis.com/css?family=Open+Sans:400,600' rel='stylesheet' type='text/css'><a href='/'><img src='/logo.jpg'></a>})
+      end
+    end
+
+    context 'when protocol is nil' do
+      it "returns the body safely, without interpolating" do
+        original_body = %{<link href='//fonts.googleapis.com/css?family=Open+Sans:400,600' rel='stylesheet' type='text/css'><a href='/'><img src='/logo.jpg'></a>}
+        body = preprocessor.process original_body, root_url, nil
+        expect(body).to eq(%{<link href='//fonts.googleapis.com/css?family=Open+Sans:400,600' rel='stylesheet' type='text/css'><a href='http://example.com/'><img src='http://example.com/logo.jpg'></a>})
+      end
+    end
+
+    context 'when root_url and protocol are both nil' do
+      it "returns the body safely, without interpolating" do
+        original_body = %{<link href='//fonts.googleapis.com/css?family=Open+Sans:400,600' rel='stylesheet' type='text/css'><a href='/'><img src='/logo.jpg'></a>}
+        body = preprocessor.process original_body, nil, nil
+        expect(body).to eq original_body
+      end
+    end
+  end
+end


### PR DESCRIPTION
@sigmavirus24 Here's a working solution for what I was proposing in #343.

To an end-user, the only effect is that the `:root_url` (and the `:protocol`) options now can be passed right to the PDFKit constructor. Configuring `root_url` still works, too.

This PR introduces `PDFKit::HtmlPreprocessor`, which could maybe also handle inserting the `<stylesheet>` tags, but I didn't want to change too much at once.

What do you think?