### PR TITLE
Minor optimizations in middleware

### DIFF
--- a/lib/pdfkit/middleware.rb
+++ b/lib/pdfkit/middleware.rb
@@ -91,7 +91,7 @@ class PDFKit
     end
 
     def conditions_as_regexp(conditions)
-      [conditions].flatten.map do |pattern|
+      Array(conditions).map do |pattern|
         pattern.is_a?(Regexp) ? pattern : Regexp.new("^#{pattern}")
       end
     end

--- a/lib/pdfkit/middleware.rb
+++ b/lib/pdfkit/middleware.rb
@@ -59,18 +59,18 @@ class PDFKit
 
     def render_as_pdf?
       request_path = @request.path
-      request_path_is_pdf = request_path.end_with?('.pdf')
+      return false unless request_path.end_with?('.pdf')
 
-      if request_path_is_pdf && @conditions[:only]
+      if @conditions[:only]
         conditions_as_regexp(@conditions[:only]).any? do |pattern|
           request_path =~ pattern
         end
-      elsif request_path_is_pdf && @conditions[:except]
+      elsif @conditions[:except]
         conditions_as_regexp(@conditions[:except]).none? do |pattern|
           request_path =~ pattern
         end
       else
-        request_path_is_pdf
+        true
       end
     end
 

--- a/lib/pdfkit/middleware.rb
+++ b/lib/pdfkit/middleware.rb
@@ -92,7 +92,7 @@ class PDFKit
 
     def conditions_as_regexp(conditions)
       [conditions].flatten.map do |pattern|
-        pattern.is_a?(Regexp) ? pattern : Regexp.new('^' + pattern)
+        pattern.is_a?(Regexp) ? pattern : Regexp.new("^#{pattern}")
       end
     end
   end

--- a/lib/pdfkit/middleware.rb
+++ b/lib/pdfkit/middleware.rb
@@ -63,11 +63,11 @@ class PDFKit
 
       if @conditions[:only]
         conditions_as_regexp(@conditions[:only]).any? do |pattern|
-          request_path =~ pattern
+          pattern === request_path
         end
       elsif @conditions[:except]
         conditions_as_regexp(@conditions[:except]).none? do |pattern|
-          request_path =~ pattern
+          pattern === request_path
         end
       else
         true

--- a/lib/pdfkit/middleware.rb
+++ b/lib/pdfkit/middleware.rb
@@ -59,7 +59,7 @@ class PDFKit
 
     def render_as_pdf?
       request_path = @request.path
-      request_path_is_pdf = request_path.match(%r{\.pdf$})
+      request_path_is_pdf = request_path.end_with?('.pdf')
 
       if request_path_is_pdf && @conditions[:only]
         conditions_as_regexp(@conditions[:only]).any? do |pattern|


### PR DESCRIPTION
This code is being used in every request to the application. So it should work as fast as possible.
What's done:

1. `end_with?` vs. `match(regexp)`

  ```ruby
  require 'benchmark/ips'
  u = 'http://www.pdf995.com/samples/pdf.pdf'

  Benchmark.ips do |x|
    x.report('match')     { u.match %r[\.pdf$] }
    x.report('end_with?') { u.end_with? '.pdf' }
    x.compare!
  end

  # Warming up --------------------------------------
  #                match    60.612k i/100ms
  #            end_with?   136.383k i/100ms
  # Calculating -------------------------------------
  #                match    934.157k (± 6.1%) i/s -      4.667M
  #            end_with?      5.115M (± 7.3%) i/s -     25.504M

  # Comparison:
  #            end_with?:  5115305.0 i/s
  #                match:   934157.4 i/s - 5.48x slower
  ```

2. `Array()` vs. `[].flatten`

  ```ruby
  require 'benchmark/ips'
  conditions = %w[a long time ago in a galaxy far far away]

  Benchmark.ips do |x|
    x.report('[].flatten') { [conditions].flatten }
    x.report('Array()')    { Array(conditions) }
    x.compare!
  end

  # Warming up --------------------------------------
  #           [].flatten    49.491k i/100ms
  #              Array()   157.466k i/100ms
  # Calculating -------------------------------------
  #           [].flatten    672.181k (± 6.2%) i/s -      3.365M
  #              Array()      8.815M (± 9.5%) i/s -     43.776M

  # Comparison:
  #              Array():  8814545.4 i/s
  #           [].flatten:   672180.8 i/s - 13.11x slower
  ```

3. Immediately return `false` in `render_as_pdf?` method if the path doesn't end with `.pdf`.
4. String interpolation is faster than concatenation.