### PR TITLE
Add configuration option `timeout` to kill wkhtmltopdf when it’s stuck

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,14 @@ Will cause the .pdf to be saved to `path/to/saved.pdf` in addition to being sent
 *  **Mangled output in the browser:** Be sure that your HTTP response
    headers specify "Content-Type: application/pdf"
 
+*  **wkhtmltopdf becomes stuck:** If you are using remote resources wkhtmltopdf
+   can occasionally become stuck due to connection issues. You can set the
+   `config.timeout` configuration to the number of seconds PDFKit should wait
+   before killing wkhtmltopdf and raising an exception.
+
+   Note: This can cause orphan process when the subprocess is run with `system`
+   instead of `exec`.
+
 ## Note on Patches/Pull Requests
 
 * Fork the project.

--- a/lib/pdfkit/configuration.rb
+++ b/lib/pdfkit/configuration.rb
@@ -1,6 +1,6 @@
 class PDFKit
   class Configuration
-    attr_accessor :meta_tag_prefix, :root_url
+    attr_accessor :meta_tag_prefix, :root_url, :timeout
     attr_writer :use_xvfb, :verbose
     attr_reader :default_options
 

--- a/spec/pdfkit_spec.rb
+++ b/spec/pdfkit_spec.rb
@@ -532,6 +532,17 @@ describe PDFKit do
       pdf = pdfkit.to_pdf
       expect(pdf[0...4]).to eq("%PDF") # PDF Signature at the beginning
     end
+
+    it "will kill wkhtmltopdf when it becomes stuck" do
+      PDFKit.configure do |config|
+        config.timeout = 2
+      end
+      pdfkit = PDFKit.new("<html><script>for (;;) {}</script></html>")
+      expect { pdfkit.to_pdf }.to raise_error /timeout/
+      PDFKit.configure do |config|
+        config.timeout = nil
+      end
+    end
   end
 
   describe "#to_file" do


### PR DESCRIPTION
A production application I'm working on has a recurring problem where, every few months, a worker job to create a PDF file becomes stuck until we manually restart the worker. This problem isn't reproducible and I suspect it is due to network connection timeout not being implemented in `wkhtmltopdf`. In https://github.com/wkhtmltopdf/wkhtmltopdf/issues/2273 it is said that users of `wkhtmltopdf` should take care of killing it themselves.

This PR uses `popen3` for more control over the `wkhtmltopdf` subprocess. This is used to implement a new configuration option `timeout` that specifies the max number of seconds the subprocess should run. As a bonus, the `stderr` output is now included in the exception message.
