### PR TITLE
Add gemspec requirements attribute

### DIFF
--- a/pdfkit.gemspec
+++ b/pdfkit.gemspec
@@ -20,7 +20,9 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  # Developmnet Dependencies
+  s.requirements << "wkhtmltopdf"
+
+  # Development Dependencies
   s.add_development_dependency(%q<activesupport>, [">= 3.0.8"])
   s.add_development_dependency(%q<mocha>, [">= 0.9.10"])
   s.add_development_dependency(%q<rack-test>, [">= 0.5.6"])


### PR DESCRIPTION
This information will appear on the gem's page on rubygems.org.
http://guides.rubygems.org/specification-reference/#requirements