### PR TITLE
Make PDFkit threadsafe

### DIFF
--- a/lib/pdfkit/middleware.rb
+++ b/lib/pdfkit/middleware.rb
@@ -9,6 +9,10 @@ class PDFKit
     end
 
     def call(env)
+      dup._call(env)
+    end
+
+    def _call(env)
       @request    = Rack::Request.new(env)
       @render_pdf = false
 

--- a/spec/middleware_spec.rb
+++ b/spec/middleware_spec.rb
@@ -381,22 +381,4 @@ describe PDFKit::Middleware do
       end
     end
   end
-
-  it "does not get stuck rendering each request as pdf" do
-    mock_app
-    # false by default. No requests.
-    expect(@app.send(:rendering_pdf?)).to eq(false)
-
-    # Remain false on a normal request
-    get 'http://www.example.org/public/file'
-    expect(@app.send(:rendering_pdf?)).to eq(false)
-
-    # Return true on a pdf request.
-    get 'http://www.example.org/public/file.pdf'
-    expect(@app.send(:rendering_pdf?)).to eq(true)
-
-    # Restore to false on any non-pdf request.
-    get 'http://www.example.org/public/file'
-    expect(@app.send(:rendering_pdf?)).to eq(false)
-  end
 end


### PR DESCRIPTION
Fixes #358.

The commits are maybe not in the best order for the long-term history - they're ordered to illuminate the problem we found, and the solution we made, in the order they came up. I hope this helps make the chain of thought clearer, and the PR easier. (Feel free to check out any particular commit, and run the specs to get a better feel for what's going on.) I'm happy to rebase however you'd like, before the final merge.

I had to upgrade .ruby-version to at least 2.2.2, because rack won't install for less than that:

```
ERROR:  Error installing rack:
        rack requires Ruby version >= 2.2.2.
```

I updated only to 2.2.2, so as to make minimal changes, and get me on my way. I'll leave the question of whether to upgrade, and to which version, to the PDFKit team: let me know, and I'll change it, or remove it.
