### PR TITLE
Ignore Bundler 1.14.* warning messages on a non-writable home directory

### DIFF
--- a/lib/pdfkit/configuration.rb
+++ b/lib/pdfkit/configuration.rb
@@ -23,7 +23,16 @@ class PDFKit
     end
 
     def default_wkhtmltopdf
-      @default_command_path ||= (defined?(Bundler::GemfileError) && File.exists?('Gemfile') ? `bundle exec which wkhtmltopdf` : `which wkhtmltopdf`).chomp
+      @default_command_path ||=
+        if defined?(Bundler::GemfileError) && File.exists?('Gemfile')
+          # Starting with Bundler 1.14, if the Bundler.rubygems.user_home value
+          # is a read-only or non-existent directory, Bundler prints out an error message.
+          # We want to ignore this message, so we want to find the first line that points
+          # to a file
+          `bundle exec which wkhtmltopdf`.lines.detect { |l| File.file?(l) }.to_s.chomp
+        else
+          `which wkhtmltopdf`.chomp
+        end
     end
 
     def wkhtmltopdf=(path)


### PR DESCRIPTION
In Bundler 1.14, there was a [merged pull request](https://github.com/bundler/bundler/pull/4951) that introduced new functionality. When running `bundle` if the location specified in `Bundler.rubygems.user_home` has a problem (e.g. does not exist, is not writable, is not a directory), it prints out a warning message to STDOUT.

You can see an example by running in bash:

```
# Set up gems with a real reference to wkhtmltopdf
gem install bundler --version 1.14.3
echo "source 'https://rubygems.org';\ngem 'wkhtmltopdf-binary-edge'" > Gemfile
bundle install --path vendor/bundle

# See the UI printout
HOME=/no/directory/found bundle exec which wkhtmltopdf
```

When run, you can see the output looks something like:

```
Your home directory is not set properly:
 * `/no/directory/found` is not a directory

Bundler will use `/var/folders/wj/q7cqmwds75z3ndcdxrmpd9gh0000gn/T/bundler/home/rdimarco` as your home directory temporarily
```

The problem is that the [output from `bundle exec which wkhtmltopdf`] (https://github.com/pdfkit/pdfkit/blob/master/lib/pdfkit/configuration.rb#L26) is used to determine the path to the default `wkhtmltopdf` executable.

So since there is the warning included in the output, the executable will not work.

This pull request is a proposal for how to ignore those warning messages so the default executable is remains correct.

NOTE: A workaround is to explicitly set the path with:

```
PDFKit.configure { |config| config..wkhtmltopdf = '/path/to/wkhtmltopdf'}
```

In our use case, we are using a gem binary, it is not ideal.

Also, if your curious why we have a read-only home directory, it happens because we have a Puma process started by upstart where the `Bundler.rubygems.user_home` winds up being `/` which the executing user does not have write access to.