### PR TITLE
Remove `config.protocol` from the README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,6 @@ PDFKit.configure do |config|
   }
   # Use only if your external hostname is unavailable on the server.
   config.root_url = "http://localhost"
-  config.protocol = 'http'
   config.verbose = false
 end
 ```


### PR DESCRIPTION
Fixes #385.

This was added in error, as part of #344, in 2febadcd028d51e73d8187745c54dabefd2597d2.

The `PDFKit` constructor _does_ support a `protocol` option, but `PDFKit::Configuration` doesn't.