### PR TITLE
Allow PDFKit middleware to receive javascript delay option

### DIFF
--- a/lib/pdfkit/middleware.rb
+++ b/lib/pdfkit/middleware.rb
@@ -22,6 +22,11 @@ class PDFKit
         root_url = root_url(env)
         protocol = protocol(env)
         options = @options.merge(root_url: root_url, protocol: protocol)
+
+        if headers['PDFKit-javascript-delay']
+          options.merge!(javascript_delay: headers.delete('PDFKit-javascript-delay').to_i)
+        end
+
         body = PDFKit.new(body, options).to_pdf
         response = [body]
 

--- a/spec/middleware_spec.rb
+++ b/spec/middleware_spec.rb
@@ -267,6 +267,51 @@ describe PDFKit::Middleware do
           end
         end
       end
+
+      describe 'javascript delay' do
+        context 'when header PDFKit-javascript-delay is present' do
+          it 'passes header value through to PDFKit initialiser' do
+            expect(PDFKit).to receive(:new).with('Hello world!', {
+              root_url: 'http://www.example.com/', protocol: 'http', javascript_delay: 4321
+            }).and_call_original
+
+            headers = { 'PDFKit-javascript-delay' => '4321' }
+            mock_app({}, { only: '/public' }, headers)
+            get 'http://www.example.com/public/test_save.pdf'
+          end
+
+          it 'handles invalid content in header' do
+            expect(PDFKit).to receive(:new).with('Hello world!', {
+              root_url: 'http://www.example.com/', protocol: 'http', javascript_delay: 0
+            }).and_call_original
+
+            headers = { 'PDFKit-javascript-delay' => 'invalid' }
+            mock_app({}, { only: '/public' }, headers)
+            get 'http://www.example.com/public/test_save.pdf'
+          end
+
+          it 'overrides default option' do
+            expect(PDFKit).to receive(:new).with('Hello world!', {
+              root_url: 'http://www.example.com/', protocol: 'http', javascript_delay: 4321
+            }).and_call_original
+
+            headers = { 'PDFKit-javascript-delay' => '4321' }
+            mock_app({ javascript_delay: 1234 }, { only: '/public' }, headers)
+            get 'http://www.example.com/public/test_save.pdf'
+          end
+        end
+
+        context 'when header PDFKit-javascript-delay is not present' do
+          it 'passes through default option' do
+            expect(PDFKit).to receive(:new).with('Hello world!', {
+              root_url: 'http://www.example.com/', protocol: 'http', javascript_delay: 1234
+            }).and_call_original
+
+            mock_app({ javascript_delay: 1234 }, { only: '/public' }, { })
+            get 'http://www.example.com/public/test_save.pdf'
+          end
+        end
+      end
     end
 
     describe "remove .pdf from PATH_INFO and REQUEST_URI" do


### PR DESCRIPTION
This change allows the page to respond with a dynamically calculated javascript delay option through the header

The code could be made pretty generic if the desire to pass other options back through was needed?