### PR TITLE
enable pdfkit meta tags with nil content

### DIFF
--- a/lib/pdfkit/pdfkit.rb
+++ b/lib/pdfkit/pdfkit.rb
@@ -89,7 +89,7 @@ class PDFKit
     content.scan(/<meta [^>]*>/) do |meta|
       if meta.match(/name=["']#{PDFKit.configuration.meta_tag_prefix}/)
         name = meta.scan(/name=["']#{PDFKit.configuration.meta_tag_prefix}([^"']*)/)[0][0].split
-        found[name] = meta.scan(/content=["']([^"'\\]+)["']/)[0][0]
+        found[name] = meta.scan(/content=["']([^"'\\]+)["']/)[0].try(:fetch, 0)
       end
     end
 


### PR DESCRIPTION
Enable users to pass pdfkit meta tags with no content property. This is needed for options like:

`<meta name:"pdfkit-footer-line">`

If you try include this meta tag without this fix, then pdfkit bugs out.