### PR TITLE
Option to force download in Middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,13 @@ config.middleware.use PDFKit::Middleware, {}, :except => [%r[^/prawn], %r[^/secr
 # conditions can be strings (either one or an array)
 config.middleware.use PDFKit::Middleware, {}, :except => ['/secret']
 ```
+**With conditions to force download**
+```ruby
+# force download with attachment disposition
+config.middleware.use PDFKit::Middleware, {}, :dispositon => 'attachment'
+# conditions can force a filename
+config.middleware.use PDFKit::Middleware, {}, :dispositon => 'attachment; filename=report.pdf'
+```
 **Saving the generated .pdf to disk**
 
 Setting the `PDFKit-save-pdf` header will cause PDFKit to write the generated .pdf to the file indicated by the value of the header.
@@ -140,13 +147,13 @@ Will cause the .pdf to be saved to `path/to/saved.pdf` in addition to being sent
    around this issue you may want to run a server with multiple workers
    like Passenger or try to embed your resources within your HTML to
    avoid extra HTTP requests.
-   
+
    Example solution (rails / bundler), add unicorn to the development
    group in your Gemfile `gem 'unicorn'` then run `bundle`. Next, add a
    file `config/unicorn.conf` with
-   
+
         worker_processes 3
-   
+
    Then to run the app `unicorn_rails -c config/unicorn.conf` (from rails_root)
 
 *  **Resources aren't included in the PDF:** Images, CSS, or JavaScript

--- a/lib/pdfkit/middleware.rb
+++ b/lib/pdfkit/middleware.rb
@@ -47,6 +47,7 @@ class PDFKit
 
         headers['Content-Length'] = (body.respond_to?(:bytesize) ? body.bytesize : body.size).to_s
         headers['Content-Type']   = 'application/pdf'
+        headers['Content-Disposition'] = @conditions[:disposition] || 'inline'
       end
 
       [status, headers, response]

--- a/spec/middleware_spec.rb
+++ b/spec/middleware_spec.rb
@@ -341,6 +341,44 @@ describe PDFKit::Middleware do
           end
         end
       end
+
+      describe ":disposition" do
+        describe "inline or blank" do
+          context "default" do
+            specify do
+              mock_app
+              get 'http://www.example.org/public/test.pdf'
+              expect(last_response.headers["Content-Disposition"]).to eq("inline")
+            end
+          end
+
+          context "inline" do
+            specify do
+              mock_app({}, { disposition: 'inline'  })
+              get 'http://www.example.org/public/test.pdf'
+              expect(last_response.headers["Content-Disposition"]).to eq("inline")
+            end
+          end
+        end
+
+        describe "attachment" do
+          context "attachment" do
+            specify do
+              mock_app({}, { disposition: 'attachment'  })
+              get 'http://www.example.org/public/test.pdf'
+              expect(last_response.headers["Content-Disposition"]).to eq("attachment")
+            end
+          end
+
+          context "attachment with filename" do
+            specify do
+              mock_app({}, { disposition: 'attachment; filename=report.pdf'  })
+              get 'http://www.example.org/public/test.pdf'
+              expect(last_response.headers["Content-Disposition"]).to eq("attachment; filename=report.pdf")
+            end
+          end
+        end
+      end
     end
 
     describe "remove .pdf from PATH_INFO and REQUEST_URI" do

--- a/spec/middleware_spec.rb
+++ b/spec/middleware_spec.rb
@@ -354,7 +354,7 @@ describe PDFKit::Middleware do
 
           context "inline" do
             specify do
-              mock_app({}, { disposition: 'inline'  })
+              mock_app({}, { :disposition => 'inline'  })
               get 'http://www.example.org/public/test.pdf'
               expect(last_response.headers["Content-Disposition"]).to eq("inline")
             end
@@ -364,7 +364,7 @@ describe PDFKit::Middleware do
         describe "attachment" do
           context "attachment" do
             specify do
-              mock_app({}, { disposition: 'attachment'  })
+              mock_app({}, { :disposition => 'attachment'  })
               get 'http://www.example.org/public/test.pdf'
               expect(last_response.headers["Content-Disposition"]).to eq("attachment")
             end
@@ -372,7 +372,7 @@ describe PDFKit::Middleware do
 
           context "attachment with filename" do
             specify do
-              mock_app({}, { disposition: 'attachment; filename=report.pdf'  })
+              mock_app({}, { :disposition => 'attachment; filename=report.pdf'  })
               get 'http://www.example.org/public/test.pdf'
               expect(last_response.headers["Content-Disposition"]).to eq("attachment; filename=report.pdf")
             end


### PR DESCRIPTION
Enable to configure the disposition on middleware.
It Allow to force download and define a filename on middleware.

This PR fixes the issue #371