### PR TITLE
Don't break verbose when assigning default options [fixes #376]

### DIFF
--- a/lib/pdfkit/configuration.rb
+++ b/lib/pdfkit/configuration.rb
@@ -1,7 +1,8 @@
 class PDFKit
   class Configuration
-    attr_accessor :meta_tag_prefix, :default_options, :root_url
+    attr_accessor :meta_tag_prefix, :root_url
     attr_writer :use_xvfb, :verbose
+    attr_reader :default_options
 
     def initialize
       @verbose         = false
@@ -50,6 +51,10 @@ class PDFKit
 
     def verbose?
       @verbose
+    end
+
+    def default_options=(options)
+      @default_options.merge!(options)
     end
   end
 

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -40,6 +40,13 @@ describe PDFKit::Configuration do
       expect(subject.default_options[:quiet]).to eql false
       expect(subject.default_options[:is_awesome]).to eql true
     end
+
+    it "merges additional options with existing defaults" do
+      subject.default_options = { quiet: false, is_awesome: true }
+      expect(subject.default_options[:quiet]).to eql false
+      expect(subject.default_options[:is_awesome]).to eql true
+      expect(subject.default_options[:disable_smart_shrinking]).to eql false
+    end
   end
 
   describe "#root_url" do


### PR DESCRIPTION
The implemented fix comes from the suggestion in #376 but I think the following fix is better: 

```diff
diff --git a/lib/pdfkit/pdfkit.rb b/lib/pdfkit/pdfkit.rb
index e8f79be..2edb883 100644
--- a/lib/pdfkit/pdfkit.rb
+++ b/lib/pdfkit/pdfkit.rb
@@ -24,7 +24,7 @@ class PDFKit
     @stylesheets = []
 
     options = PDFKit.configuration.default_options.merge(options)
-    options.delete(:quiet) if PDFKit.configuration.verbose?
+    options[:quiet] = !PDFKit.configuration.verbose? unless options.include?(:quiet)
     options.merge! find_options_in_meta(url_file_or_html) unless source.url?
     @root_url = options.delete(:root_url)
     @protocol = options.delete(:protocol)
```

Thoughts? 