### PR TITLE
Gemspec: Drop EOL'd property rubyforge_project

### DIFF
--- a/pdfkit.gemspec
+++ b/pdfkit.gemspec
@@ -13,8 +13,6 @@ Gem::Specification.new do |s|
   s.description = "Uses wkhtmltopdf to create PDFs using HTML"
   s.license     = "MIT"
 
-  s.rubyforge_project = "pdfkit"
-
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }


### PR DESCRIPTION
The RubyGems property rubyforge_project is removed without a replacement.