### PR TITLE
Update Travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,16 @@
+language: ruby
+
 rvm:
-- 2.2
 - 2.3
 - 2.4
 - 2.5
+- 2.6
 
 before_install:
   - gem update --system
   - gem update bundler
 
 before_script:
-  - "export DISPLAY=:99.0"
-  - "sh -e /etc/init.d/xvfb start"
   - "sudo apt-get -qq -y install fontconfig libxrender1"
-  - "wget https://downloads.wkhtmltopdf.org/0.12/0.12.5/wkhtmltox_0.12.5-1.trusty_amd64.deb"
-  - "sudo apt-get install ./wkhtmltox_0.12.5-1.trusty_amd64.deb"
+  - "wget https://downloads.wkhtmltopdf.org/0.12/0.12.5/wkhtmltox_0.12.5-1.xenial_amd64.deb"
+  - "sudo apt-get install ./wkhtmltox_0.12.5-1.xenial_amd64.deb"


### PR DESCRIPTION
Ruby 2.2 is EOL. 

Bundler also dropped support for Ruby 2.2: https://docs.travis-ci.com/user/languages/ruby/#bundler-20

Ubuntu Xenial 16.04 is the default. Precise and Trusty are EOL by Canonical: https://docs.travis-ci.com/user/reference/linux/

Fix #450