### PR TITLE
Only grab last line of bundle exec which output

### DIFF
--- a/lib/pdfkit/configuration.rb
+++ b/lib/pdfkit/configuration.rb
@@ -27,7 +27,7 @@ class PDFKit
     def default_wkhtmltopdf
       return @default_command_path if @default_command_path
       if defined?(Bundler::GemfileError) && File.exists?('Gemfile')
-        @default_command_path = `bundle exec which wkhtmltopdf`.chomp
+        @default_command_path = `bundle exec which wkhtmltopdf`.chomp.lines.last
       end
       @default_command_path = `which wkhtmltopdf`.chomp if @default_command_path.nil? || @default_command_path.empty?
       @default_command_path

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -34,6 +34,17 @@ describe PDFKit::Configuration do
           expect(subject).to receive(:`).with('which wkhtmltopdf').and_return("c:\\windows\\path.exe\n")
           expect(subject.wkhtmltopdf).to eq('c:\windows\path.exe')
         end
+
+        it "returns last line of 'bundle exec which' output" do
+          # Happens when the user does not have a HOME directory on their system and runs bundler < 2
+          expect(subject).to receive(:`).with('bundle exec which wkhtmltopdf').and_return(<<~EOT
+            `/home/myuser` is not a directory.
+            Bundler will use `/tmp/bundler/home/myuser' as your home directory temporarily.
+            /usr/bin/wkhtmltopdf
+          EOT
+          )
+          expect(subject.wkhtmltopdf).to eq('/usr/bin/wkhtmltopdf')
+        end
       end
 
       context "when running without bundler" do


### PR DESCRIPTION
When running pdfkit in a docker container for our configuration, there is no home directory. Bundler < 2 has a warning for this and it goes to STDOUT (see: https://github.com/rubygems/bundler/issues/6067). Here is the example:

```ruby
irb(main):001:0> `bundle exec which wkhtmltopdf`.chomp
=> "`/home/myuser` is not a directory.\nBundler will use `/tmp/bundler/home/myuser' as your home directory temporarily.\n/usr/bin/wkhtmltopdf"
irb(main):002:0> `bundle exec which wkhtmltopdf`.chomp.lines.last
=> "/usr/bin/wkhtmltopdf"
```

Now an example where the warning does not come up:

```ruby
2.4.6 :001 > `bundle exec which wkhtmltopdf`.chomp
 => "/usr/local/bin/wkhtmltopdf"
2.4.6 :002 > `bundle exec which wkhtmltopdf`.chomp.lines.last
 => "/usr/local/bin/wkhtmltopdf"
```

This PR seems to be very similar to the recently merged https://github.com/pdfkit/pdfkit/pull/460

Looking forward to your feedback.
