### PR TITLE
Don't override request level Content-Disposition header if it exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,9 +119,9 @@ config.middleware.use PDFKit::Middleware, {}, :except => ['/secret']
 **With conditions to force download**
 ```ruby
 # force download with attachment disposition
-config.middleware.use PDFKit::Middleware, {}, :dispositon => 'attachment'
+config.middleware.use PDFKit::Middleware, {}, :disposition => 'attachment'
 # conditions can force a filename
-config.middleware.use PDFKit::Middleware, {}, :dispositon => 'attachment; filename=report.pdf'
+config.middleware.use PDFKit::Middleware, {}, :disposition => 'attachment; filename=report.pdf'
 ```
 **Saving the generated .pdf to disk**
 

--- a/lib/pdfkit/middleware.rb
+++ b/lib/pdfkit/middleware.rb
@@ -47,7 +47,7 @@ class PDFKit
 
         headers['Content-Length'] = (body.respond_to?(:bytesize) ? body.bytesize : body.size).to_s
         headers['Content-Type']   = 'application/pdf'
-        headers['Content-Disposition'] = @conditions[:disposition] || 'inline'
+        headers['Content-Disposition'] ||= @conditions[:disposition] || 'inline'
       end
 
       [status, headers, response]

--- a/spec/middleware_spec.rb
+++ b/spec/middleware_spec.rb
@@ -343,6 +343,20 @@ describe PDFKit::Middleware do
       end
 
       describe ":disposition" do
+        describe "doesn't overwrite existing value" do
+          let(:headers) do
+            super().merge({
+              'Content-Disposition' => 'attachment; filename=report-20200101.pdf'
+            })
+          end
+
+          specify do
+            mock_app({}, { :disposition => 'inline' })
+            get 'http://www.example.org/public/test.pdf'
+            expect(last_response.headers["Content-Disposition"]).to eq('attachment; filename=report-20200101.pdf')
+          end
+        end
+
         describe "inline or blank" do
           context "default" do
             specify do


### PR DESCRIPTION
#437 added the ability to specify disposition at the middleware level.
However, this had the unexpected side-effect of steamrolling any per-request disposition headers currently set, which was a pretty massive change in behaviour in a patch release.

This updates the logic to only set the Content Disposition header if it doesn't already exist.