### PR TITLE
Add missing require statements for tempfile

### DIFF
--- a/lib/pdfkit/pdfkit.rb
+++ b/lib/pdfkit/pdfkit.rb
@@ -1,4 +1,5 @@
 require 'shellwords'
+require 'tempfile'
 
 class PDFKit
   class Error < StandardError; end

--- a/lib/pdfkit/source.rb
+++ b/lib/pdfkit/source.rb
@@ -1,3 +1,4 @@
+require 'tempfile'
 require 'uri'
 
 class PDFKit


### PR DESCRIPTION
When pdfkit is used in an rspec test run using the rspec binary, the
tests pass even with the missing require for tempfile, because rspec
is bringing in tempfile.  But running pdfkit outside of a test
environment, in a project that is not already bringing in tempfile,
will fail.

The test for this is:

```
#!/usr/bin/env ruby

require "pdfkit"

PDFKit.new("")
```

Which results in a stack trace including:

```
/home/wayne/.rvm/gems/ruby-2.7.1/gems/pdfkit-0.8.4.2/lib/pdfkit/pdfkit.rb:94:in `find_options_in_meta': uninitialized constant PDFKit::Tempfile (NameError)
```

I don't know how to make a good test for this in rspec, since rspec hides the problem by bringing in the missing library.  I guess the test could shell out to a little test file like the one above, but I don't know if that's worth the trouble.
