### PR TITLE
Return 500 status when an exception is caught in middleware

### DIFF
--- a/lib/pdfkit/middleware.rb
+++ b/lib/pdfkit/middleware.rb
@@ -51,6 +51,12 @@ class PDFKit
       end
 
       [status, headers, response]
+
+    rescue StandardError => e
+      status = 500
+      response = [e.message]
+
+      [status, headers, response]
     end
 
     private

--- a/spec/middleware_spec.rb
+++ b/spec/middleware_spec.rb
@@ -379,6 +379,16 @@ describe PDFKit::Middleware do
           end
         end
       end
+
+      describe "error handling" do
+        specify do
+          mock_app
+          allow(PDFKit).to receive(:new).and_raise(StandardError.new("Something went wrong"))
+          get 'http://www.example.org/public/test.pdf'
+          expect(last_response.status).to eq(500)
+          expect(last_response.body).to eq("Something went wrong")
+        end
+      end
     end
 
     describe "remove .pdf from PATH_INFO and REQUEST_URI" do


### PR DESCRIPTION
If an error occurs in the middleware we should reflect that in the response status instead of echoing the success of the unmodified response.

This will help with response status test assertions. We recently had middleware misconfiguration issues which were not caught by tests expecting a 200 response.