### PR TITLE
[require] tempfile if not already defined

### DIFF
--- a/lib/pdfkit/pdfkit.rb
+++ b/lib/pdfkit/pdfkit.rb
@@ -1,4 +1,5 @@
 require 'shellwords'
+require 'tempfile' if not defined?(Tempfile)
 
 class PDFKit
   class Error < StandardError; end

--- a/lib/pdfkit/source.rb
+++ b/lib/pdfkit/source.rb
@@ -1,4 +1,5 @@
 require 'uri'
+require 'tempfile' if not defined?(Tempfile)
 
 class PDFKit
   class Source


### PR DESCRIPTION
I tried to use with both ruby `2.5` and `2.7` and it failed because `Tempfile` is not defined