### PR TITLE
Fix to render stylesheets as html safe string on Rails 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,12 @@ rvm:
 - 2.5
 - 2.6
 
+env:
+  matrix:
+    - RAILS_VERSION="~> 4.1"
+    - RAILS_VERSION="~> 5.2"
+    - RAILS_VERSION="~> 6.0.0"
+
 before_install:
   - gem update --system
   - gem update bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: ruby
 
 rvm:
-- 2.3
-- 2.4
 - 2.5
 - 2.6
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 group :test do
-  gem 'activesupport', '~> 4.1'
+  gem 'activesupport', ENV['RAILS_VERSION'] || '~> 4.1'
   gem 'simplecov', require: false
 end
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 Create PDFs using plain old HTML+CSS. Uses [wkhtmltopdf](http://github.com/antialize/wkhtmltopdf) on the back-end which renders HTML using Webkit.
 
+## Supported versions
+
+- Ruby 2.5, 2.6
+- Rails 4.2, 5.2, 6.0
+
 ## Install
 
 ### PDFKit

--- a/lib/pdfkit/pdfkit.rb
+++ b/lib/pdfkit/pdfkit.rb
@@ -114,7 +114,9 @@ class PDFKit
   end
 
   def style_tag_for(stylesheet)
-    "<style>#{File.read(stylesheet)}</style>"
+    style = "<style>#{File.read(stylesheet)}</style>"
+    style = style.html_safe if style.respond_to?(:html_safe)
+    style
   end
 
   def preprocess_html
@@ -129,7 +131,9 @@ class PDFKit
 
     stylesheets.each do |stylesheet|
       if @source.to_s.match(/<\/head>/)
-        @source = Source.new(@source.to_s.gsub(/(<\/head>)/) {|s| style_tag_for(stylesheet) + s })
+        @source = Source.new(@source.to_s.gsub(/(<\/head>)/) {|s|
+          style_tag_for(stylesheet) + (s.respond_to?(:html_safe) ? s.html_safe : s)
+        })
       else
         @source.to_s.insert(0, style_tag_for(stylesheet))
       end

--- a/pdfkit.gemspec
+++ b/pdfkit.gemspec
@@ -18,6 +18,8 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
+  s.required_ruby_version = '>= 2.5'
+
   s.requirements << "wkhtmltopdf"
 
   # Development Dependencies

--- a/spec/pdfkit_spec.rb
+++ b/spec/pdfkit_spec.rb
@@ -501,6 +501,14 @@ describe PDFKit do
       expect(pdfkit.source.to_s).to include("<style>#{File.read(css)}</style></head>")
     end
 
+    it "can deal with ActiveSupport::SafeBuffer if the HTML doesn't have a head tag" do
+      pdfkit = PDFKit.new(ActiveSupport::SafeBuffer.new "<html><body>Hai!</body></html>")
+      css = File.join(SPEC_ROOT,'fixtures','example.css')
+      pdfkit.stylesheets << css
+      pdfkit.to_pdf
+      expect(pdfkit.source.to_s).to include("<style>#{File.read(css)}</style>")
+    end
+
     it "escapes \\X in stylesheets" do
       pdfkit = PDFKit.new("<html><head></head><body>Hai!</body></html>")
       css = File.join(SPEC_ROOT,'fixtures','example_with_hex_symbol.css')


### PR DESCRIPTION
In Rails 6, the spec of `ActiveSupport::SafeBuffer` methods has been changed.
Previously, it behaves like just String, but now `ActiveSupport::SafeBuffer` exactly.
See for details: https://github.com/rails/rails/pull/33990

This change breaks stylesheets rendering.
The rendered PDF has too escaped style tag.

There is a result of failing spec that I added in 760a8edbaa0534aaf4dd02b718ea17dc2671c157.
``` console
$ RAILS_VERSION="~> 6.0.0" bundle exec rspec spec/pdfkit_spec.rb:504
Run options: include {:locations=>{"./spec/pdfkit_spec.rb"=>[504]}}
F

Failures:

  1) PDFKit#to_pdf can deal with ActiveSupport::SafeBuffer if the HTML doesn't have a head tag
     Failure/Error: expect(pdfkit.source.to_s).to include("<style>#{File.read(css)}</style>")
       expected "&lt;style&gt;body { font-size: 20px; }&lt;/style&gt;<html><body>Hai!</body></html>" to include "<style>body { font-size: 20px; }</style>"
     # ./spec/pdfkit_spec.rb:509:in `block (3 levels) in <top (required)>'

Finished in 1.74 seconds (files took 0.38544 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/pdfkit_spec.rb:504 # PDFKit#to_pdf can deal with ActiveSupport::SafeBuffer if the HTML doesn't have a head tag
```
