### PR TITLE
Enable bundler caching for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ env:
     - RAILS_VERSION="~> 5.2"
     - RAILS_VERSION="~> 6.0.0"
 
+cache: bundler
+
 before_install:
   - gem update --system
   - gem update bundler


### PR DESCRIPTION
Would be interested to know why bundler caching of Travis hasn't been enabled in this repository. Thank you.