### PR TITLE
Use WEBric:HTTPUtils instead of deprecated URI for ruby 3.0

### DIFF
--- a/lib/pdfkit/source.rb
+++ b/lib/pdfkit/source.rb
@@ -1,5 +1,6 @@
 require 'tempfile'
 require 'uri'
+require 'webrick'
 
 class PDFKit
   class Source
@@ -38,11 +39,11 @@ class PDFKit
     private
 
     def shell_safe_url
-      url_needs_escaping? ? URI::escape(@source) : @source
+      url_needs_escaping? ? WEBrick::HTTPUtils.escape(@source) : @source
     end
 
     def url_needs_escaping?
-      URI::decode(@source) == @source
+      WEBrick::HTTPUtils.unescape(@source) == @source
     end
   end
 end

--- a/pdfkit.gemspec
+++ b/pdfkit.gemspec
@@ -29,4 +29,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency(%q<rake>, ["~>12.3.3"])
   s.add_development_dependency(%q<rdoc>, ["~> 4.0.1"])
   s.add_development_dependency(%q<rspec>, ["~> 3.0"])
+
+  # Runtime Dependencies
+  s.add_runtime_dependency(%q<webrick>, [">= 1.0"])
 end


### PR DESCRIPTION
With ruby 3.0, deprecated URI.espace / unespace is removed:
https://github.com/ruby/uri/commit/61c6a47ebf

Use WEBric:HTTPUtils instread. Also add webrick dependency to
runtime.

Fixes #485 