### PR TITLE
Enable tests on GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,9 +20,9 @@ jobs:
 
     - name: Setup wkhtmltopdf
       run: |
-        sudo apt-get -qq -y install fontconfig libxrender1
-        wget https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.5/wkhtmltox_0.12.5-1.xenial_amd64.deb
-        sudo apt-get install ./wkhtmltox_0.12.5-1.xenial_amd64.deb
+        sudo apt-get install -y xfonts-base xfonts-75dpi
+        wget https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6-1/wkhtmltox_0.12.6-1.bionic_amd64.deb
+        sudo dpkg -i wkhtmltox_0.12.6-1.bionic_amd64.deb
 
     - name: Run tests
       run: bundle exec rake

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,28 @@
+name: Test workflow
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        ruby: [2.6, 2.7]
+        rails: ['~> 4.1', '~> 5.2', '~> 6.0']
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v2
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby }}
+        bundler-cache: true
+
+    - name: Setup wkhtmltopdf
+      run: |
+        sudo apt-get -qq -y install fontconfig libxrender1
+        wget https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.5/wkhtmltox_0.12.5-1.xenial_amd64.deb
+        sudo apt-get install ./wkhtmltox_0.12.5-1.xenial_amd64.deb
+
+    - name: Run tests
+      run: bundle exec rake

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        ruby: [2.6, 2.7]
+        ruby: [2.5, 2.6, 2.7]
         rails: ['~> 4.1', '~> 5.2', '~> 6.0']
     runs-on: ${{ matrix.os }}
     env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,8 @@ jobs:
         ruby: [2.6, 2.7]
         rails: ['~> 4.1', '~> 5.2', '~> 6.0']
     runs-on: ${{ matrix.os }}
+    env:
+      RAILS_VERSION: ${{ matrix.rails }}
     steps:
     - uses: actions/checkout@v2
     - uses: ruby/setup-ruby@v1


### PR DESCRIPTION
Migrate from TravisCI to Github Actions. Please note that the wkhtmltopdf binary had been updated to the latest `0.12.6-1` in the test workflow.