### PR TITLE
Unescaped urls are now shell escaped

### DIFF
--- a/lib/pdfkit/source.rb
+++ b/lib/pdfkit/source.rb
@@ -44,7 +44,7 @@ class PDFKit
     def shell_safe_url
       if url_needs_escaping?
         URI::DEFAULT_PARSER.escape(@source)
-      elsif url_has_backticks?
+      elsif url_has_shellcode?
         @source.shellescape
       else
         @source
@@ -55,8 +55,13 @@ class PDFKit
       URI::DEFAULT_PARSER.unescape(@source) == @source
     end
 
-    def url_has_backticks?
-      @source.include? '`'
+    def url_has_shellcode?
+      possible_shellcodes = [
+        '`',
+        '$('
+      ]
+
+      possible_shellcodes.select { |code| @source.include?(code) }.any?
     end
   end
 end

--- a/lib/pdfkit/source.rb
+++ b/lib/pdfkit/source.rb
@@ -42,7 +42,7 @@ class PDFKit
     private
 
     def shell_safe_url
-      url_needs_escaping? ? URI::DEFAULT_PARSER.escape(@source) : @source
+      url_needs_escaping? ? URI::DEFAULT_PARSER.escape(@source) : @source.shellescape
     end
 
     def url_needs_escaping?

--- a/lib/pdfkit/source.rb
+++ b/lib/pdfkit/source.rb
@@ -42,11 +42,21 @@ class PDFKit
     private
 
     def shell_safe_url
-      url_needs_escaping? ? URI::DEFAULT_PARSER.escape(@source) : @source.shellescape
+      if url_needs_escaping?
+        URI::DEFAULT_PARSER.escape(@source)
+      elsif url_has_backticks?
+        @source.shellescape
+      else
+        @source
+      end
     end
 
     def url_needs_escaping?
       URI::DEFAULT_PARSER.unescape(@source) == @source
+    end
+
+    def url_has_backticks?
+      @source.include? '`'
     end
   end
 end

--- a/lib/pdfkit/source.rb
+++ b/lib/pdfkit/source.rb
@@ -42,26 +42,11 @@ class PDFKit
     private
 
     def shell_safe_url
-      if url_needs_escaping?
-        URI::DEFAULT_PARSER.escape(@source)
-      elsif url_has_shellcode?
-        @source.shellescape
-      else
-        @source
-      end
+      URI::parse(unescaped_source).to_s
     end
 
-    def url_needs_escaping?
-      URI::DEFAULT_PARSER.unescape(@source) == @source
-    end
-
-    def url_has_shellcode?
-      possible_shellcodes = [
-        '`',
-        '$('
-      ]
-
-      possible_shellcodes.select { |code| @source.include?(code) }.any?
+    def unescaped_source
+      URI::DEFAULT_PARSER.unescape(@source)
     end
   end
 end

--- a/spec/source_spec.rb
+++ b/spec/source_spec.rb
@@ -100,7 +100,7 @@ describe PDFKit::Source do
       expect(source.to_input_for_command).to match file.path
     end
 
-    it "shellescapes to prevent shell execution" do
+    it "should not allow backtick shell execution in url" do
       filename = "/tmp/deleteme_please.txt"
 
       if File.file?(filename)
@@ -113,6 +113,19 @@ describe PDFKit::Source do
         PDFKit.new("http%20`touch #{filename}`").to_pdf
       rescue PDFKit::ImproperWkhtmltopdfExitStatus
       end
+      expect(File.file?(filename)).to eq false
+    end
+
+    it "should not allow $( shell execution in url" do
+      filename = "/tmp/deleteme_please.txt"
+
+      if File.file?(filename)
+        File.delete(filename)
+      end
+      source = PDFKit::Source.new("http://example.com/?name={'%20$(sleep 5)'}")
+      expect(source.to_input_for_command).to eq "\"http://example.com/\\?name\\=\\{\\'\\%20\\$\\(sleep\\ 5\\)\\'\\}\""
+
+      PDFKit.new("http%20$(touch #{filename})").to_pdf
       expect(File.file?(filename)).to eq false
     end
   end

--- a/spec/source_spec.rb
+++ b/spec/source_spec.rb
@@ -99,6 +99,22 @@ describe PDFKit::Source do
       source = PDFKit::Source.new(file = ::Tempfile.new(__FILE__))
       expect(source.to_input_for_command).to match file.path
     end
+
+    it "shellescapes to prevent shell execution" do
+      filename = "/tmp/deleteme_please.txt"
+
+      if File.file?(filename)
+        File.delete(filename)
+      end
+      source = PDFKit::Source.new("http://example.com/?name={'%20`sleep 5`'}")
+      expect(source.to_input_for_command).to eq "\"http://example.com/\\?name\\=\\{\\'\\%20\\`sleep\\ 5\\`\\'\\}\""
+
+      begin
+        PDFKit.new("http%20`touch #{filename}`").to_pdf
+      rescue PDFKit::ImproperWkhtmltopdfExitStatus
+      end
+      expect(File.file?(filename)).to eq false
+    end
   end
 
   describe "#to_s" do

--- a/spec/source_spec.rb
+++ b/spec/source_spec.rb
@@ -101,7 +101,7 @@ describe PDFKit::Source do
     end
 
     it "should not allow backtick shell execution in url" do
-      filename = "/tmp/deleteme_please.txt"
+      filename = Dir::Tmpname.create('backtick_file') { |path| path }
 
       if File.file?(filename)
         File.delete(filename)
@@ -117,7 +117,7 @@ describe PDFKit::Source do
     end
 
     it "should not allow $( shell execution in url" do
-      filename = "/tmp/deleteme_please.txt"
+      filename = Dir::Tmpname.create('dolar_sign_file') { |path| path }
 
       if File.file?(filename)
         File.delete(filename)
@@ -125,7 +125,10 @@ describe PDFKit::Source do
       source = PDFKit::Source.new("http://example.com/?name={'%20$(sleep 5)'}")
       expect(source.to_input_for_command).to eq "\"http://example.com/\\?name\\=\\{\\'\\%20\\$\\(sleep\\ 5\\)\\'\\}\""
 
+      begin
       PDFKit.new("http%20$(touch #{filename})").to_pdf
+      rescue PDFKit::ImproperWkhtmltopdfExitStatus
+      end
       expect(File.file?(filename)).to eq false
     end
   end


### PR DESCRIPTION
This helps address [CVE-2022-25765](https://www.cve.org/CVERecord?id=CVE-2022-25765) referenced in issue #507 allowing shell commands in backticks when calling wkhtmltopdf by shellescaping URLs not needing URI::Parse escaping.