### PR TITLE
Call `IO.popen` with an Array of command arguments (#518).

### DIFF
--- a/lib/pdfkit/configuration.rb
+++ b/lib/pdfkit/configuration.rb
@@ -45,7 +45,7 @@ class PDFKit
     end
 
     def executable
-      using_xvfb? ? "xvfb-run #{wkhtmltopdf}" : wkhtmltopdf
+      using_xvfb? ? ['xvfb-run', wkhtmltopdf] : wkhtmltopdf
     end
 
     def using_xvfb?

--- a/lib/pdfkit/pdfkit.rb
+++ b/lib/pdfkit/pdfkit.rb
@@ -46,16 +46,11 @@ class PDFKit
   end
 
   def command(path = nil)
-    args = @renderer.options_for_command
-    shell_escaped_command = [executable, OS::shell_escape_for_os(args)].join ' '
-
-    # In order to allow for URL parameters (e.g. https://www.google.com/search?q=pdfkit) we do
-    # not escape the source. The user is responsible for ensuring that no vulnerabilities exist
-    # in the source. Please see https://github.com/pdfkit/pdfkit/issues/164.
-    input_for_command = @source.to_input_for_command
-    output_for_command = path ? Shellwords.shellescape(path) : '-'
-
-    "#{shell_escaped_command} #{input_for_command} #{output_for_command}"
+    args = [*executable]
+    args.concat(@renderer.options_for_command)
+    args << @source.to_input_for_command
+    args << (path ? path : '-')
+    args
   end
 
   def options

--- a/lib/pdfkit/source.rb
+++ b/lib/pdfkit/source.rb
@@ -29,7 +29,7 @@ class PDFKit
       if file?
         @source.path
       elsif url?
-        %{"#{shell_safe_url}"}
+        escaped_url
       else
         SOURCE_FROM_STDIN
       end
@@ -41,7 +41,7 @@ class PDFKit
 
     private
 
-    def shell_safe_url
+    def escaped_url
       url_needs_escaping? ? URI::DEFAULT_PARSER.escape(@source) : @source
     end
 

--- a/lib/pdfkit/wkhtmltopdf.rb
+++ b/lib/pdfkit/wkhtmltopdf.rb
@@ -64,7 +64,7 @@ class PDFKit
       when Array
         value.flatten.collect{|x| x.to_s}
       else
-        (OS::host_is_windows? && value.to_s.index(' ')) ? "'#{ value.to_s }'" : value.to_s
+        value.to_s
       end
     end
   

--- a/spec/source_spec.rb
+++ b/spec/source_spec.rb
@@ -75,19 +75,14 @@ describe PDFKit::Source do
   end
 
   describe "#to_input_for_command" do
-    it "URI escapes source URLs and encloses them in quotes to accomodate ampersands" do
-      source = PDFKit::Source.new("https://www.google.com/search?q='cat<dev/zero>/dev/null'")
-      expect(source.to_input_for_command).to eq "\"https://www.google.com/search?q='cat%3Cdev/zero%3E/dev/null'\""
-    end
-
-    it "URI escapes source URI only escape part of it" do
-      source = PDFKit::Source.new("https://www.google.com/search?q='%20 sleep 5'")
-      expect(source.to_input_for_command).to eq "\"https://www.google.com/search?q='%2520%20sleep%205'\""
+    it "URI escapes source URI" do
+      source = PDFKit::Source.new("https://www.google.com/search?q=foo bar")
+      expect(source.to_input_for_command).to eq "https://www.google.com/search?q=foo%20bar"
     end
 
     it "does not URI escape previously escaped source URLs" do
-      source = PDFKit::Source.new("https://www.google.com/search?q='cat%3Cdev/zero%3E/dev/null'")
-      expect(source.to_input_for_command).to eq "\"https://www.google.com/search?q='cat%3Cdev/zero%3E/dev/null'\""
+      source = PDFKit::Source.new("https://www.google.com/search?q=foo%20bar")
+      expect(source.to_input_for_command).to eq "https://www.google.com/search?q=foo%20bar"
     end
 
     it "returns a '-' for HTML strings to indicate that we send that content through STDIN" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,3 +21,13 @@ require 'custom_wkhtmltopdf_path' if File.exist?(File.join(SPEC_ROOT, 'custom_wk
 RSpec.configure do |config|
   include Rack::Test::Methods
 end
+
+RSpec::Matchers.define :contain do |expected|
+  match do |actual|
+    (0..(actual.length - expected.length)).any? do |base_index|
+      expected.each_with_index.all? do |expected_element,index|
+        actual[base_index+index] == expected_element
+      end
+    end
+  end
+end


### PR DESCRIPTION
I hope this is a simpler solution to #518 as it avoids complex shell-escaping/input-sanitizing logic in favor of calling `IO.popen` with an Array of separate command arguments.

* By calling `IO.popen` with an Array of command arguments (ex: `['ls', '-l', ...]`) it runs the command as a separate process instead of running it in a sub-shell as a shell command. This prevents any arbitrary command injection, without needing complex shell-escaping logic. https://ruby-doc.org/core-3.1.2/IO.html#method-c-popen
* Changed `Configuration#executable` to return a String or an Array for when xvfb mode is enabled.
* Changed `PDFKit#command` to return an Array of command arguments for `IO.popen`.
* Removed argument quoting logic as it's not necessary when calling `IO.popen` with an Array of arguments.
* Rewrote some specs to test if the command's Array of arguments contains specific argument values.
* Added a custom RSpec `contain` matcher for testing if an expected Array exists within another Array.