### PR TITLE
Allow passing a `Pathname` object to the `path` argument

### DIFF
--- a/lib/pdfkit/pdfkit.rb
+++ b/lib/pdfkit/pdfkit.rb
@@ -49,7 +49,7 @@ class PDFKit
     args = [*executable]
     args.concat(@renderer.options_for_command)
     args << @source.to_input_for_command
-    args << (path ? path : '-')
+    args << (path ? path.to_s : '-')
     args
   end
 

--- a/spec/pdfkit_spec.rb
+++ b/spec/pdfkit_spec.rb
@@ -181,6 +181,20 @@ describe PDFKit do
       expect(command).to contain %w[--replace foo bar]
     end
 
+    it "contains a specified by path argument" do
+      pdfkit = PDFKit.new('html')
+      command = pdfkit.command("/foo/bar")
+      expect(command.first).to match(/wkhtmltopdf/)
+      expect(command.last).to eq("/foo/bar")
+    end
+
+    it "contains a specified by path argument of Pathname" do
+      pdfkit = PDFKit.new('html')
+      command = pdfkit.command(Pathname.new("/foo/bar"))
+      expect(command.first).to match(/wkhtmltopdf/)
+      expect(command.last).to eq("/foo/bar")
+    end
+
     it "sets up one cookie when hash has only one cookie" do
       pdfkit = PDFKit.new('html', cookie: {cookie_name: :cookie_value})
       command = pdfkit.command


### PR DESCRIPTION
I got the below error when passing `Pathname` object to `PDFKit#to_file` in PDFKit v0.8.7.2.
```
TypeError:
  no implicit conversion of Pathname into String
# /bundle/ruby/2.7.0/gems/pdfkit-0.8.7.2/lib/pdfkit/pdfkit.rb:71:in `popen'
# /bundle/ruby/2.7.0/gems/pdfkit-0.8.7.2/lib/pdfkit/pdfkit.rb:71:in `to_pdf'
# /bundle/ruby/2.7.0/gems/pdfkit-0.8.7.2/lib/pdfkit/pdfkit.rb:84:in `to_file'
```

I think this error introduced in v0.8.7.2(#519).
