### PR TITLE
V0.8.7.3 build failure fixes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,6 +48,7 @@ jobs:
         rubygems: default
         bundler: latest
         bundler-cache: true
+        cache-version: 1
 
     - name: Setup wkhtmltopdf
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,7 +48,6 @@ jobs:
         rubygems: default
         bundler: latest
         bundler-cache: true
-        cache-version: 1
 
     - name: Setup wkhtmltopdf
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,7 +45,7 @@ jobs:
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
-        rubygems: latest
+        rubygems: default
         bundler: latest
         bundler-cache: true
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,7 +48,6 @@ jobs:
         rubygems: latest
         bundler: latest
         bundler-cache: true
-        cache-version: 0.1
 
     - name: Setup wkhtmltopdf
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,6 +43,9 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: ruby/setup-ruby@v1
+      # rubygems-update's latest is no longer compatible with ruby 2.5, so conditionally run ruby-setup setting the
+      # rubygem version the most recent valid version for 2.5:
+      # https://rubygems.org/gems/rubygems-update/versions/3.3.26
       if: ${{ matrix.ruby == '2.5' }}
       with:
         ruby-version: ${{ matrix.ruby }}
@@ -50,6 +53,7 @@ jobs:
         bundler: latest
         bundler-cache: true
     - uses: ruby/setup-ruby@v1
+      # otherwise, we can use rubygems latest
       if: ${{ matrix.ruby != '2.5' }}
       with:
         ruby-version: ${{ matrix.ruby }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,9 +43,17 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: ruby/setup-ruby@v1
+      if: ${{ matrix.ruby == '2.5' }}
       with:
         ruby-version: ${{ matrix.ruby }}
-        rubygems: default
+        rubygems: 3.3.26
+        bundler: latest
+        bundler-cache: true
+    - uses: ruby/setup-ruby@v1
+      if: ${{ matrix.ruby != '2.5' }}
+      with:
+        ruby-version: ${{ matrix.ruby }}
+        rubygems: latest
         bundler: latest
         bundler-cache: true
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,6 +48,7 @@ jobs:
         rubygems: latest
         bundler: latest
         bundler-cache: true
+        cache-version: 0.1
 
     - name: Setup wkhtmltopdf
       run: |

--- a/spec/pdfkit_spec.rb
+++ b/spec/pdfkit_spec.rb
@@ -45,8 +45,8 @@ describe PDFKit do
     end
 
     it "transforms complex keys into command-line arguments" do
-      pdfkit = PDFKit.new('html', :replace => {'value' => 'something else'} )
-      expect(pdfkit.options).to have_key('--replace')
+      pdfkit = PDFKit.new('html', :header_left => {'value' => 'something else'} )
+      expect(pdfkit.options).to have_key('--header-left')
     end
 
     it "drops options with false or falsey values" do
@@ -72,8 +72,8 @@ describe PDFKit do
     end
 
     it "parses hash option values into an array" do
-      pdfkit = PDFKit.new('html', :replace => {'value' => 'something else'} )
-      expect(pdfkit.options['--replace']).to eql ['value', 'something else']
+      pdfkit = PDFKit.new('html', :header_left => {'value' => 'something else'} )
+      expect(pdfkit.options['--header-left']).to eql ['value', 'something else']
     end
 
     it "flattens hash options into the key" do
@@ -84,8 +84,8 @@ describe PDFKit do
     end
 
     it "parses array option values into a string" do
-      pdfkit = PDFKit.new('html', :replace => ['value', 'something else'] )
-      expect(pdfkit.options['--replace']).to eql ['value', 'something else']
+      pdfkit = PDFKit.new('html', :header_left => ['value', 'something else'] )
+      expect(pdfkit.options['--header-left']).to eql ['value', 'something else']
     end
 
     it "flattens array options" do


### PR DESCRIPTION
Hey there!

The bump to v0.8.7.3 in #529 looks like it was failing due to a couple of issues:

- The `ruby/setup-ruby@v1` action, when running with Ruby 2.5, cannot use the most recent `rubygem-updater`
- Some specs involving complex key examples were using `--replace`, to validate it could parse `wkhtmltopdf` options that handle multiple options, that started to fail with the changes in #523  
 

This PR updates the specs to use `header-left`, which also [takes complex keys](https://github.com/wkhtmltopdf/wkhtmltopdf/blob/6a57c1449797d6cb915921fb747f3ac36199241f/docs/usage/wkhtmltopdf.txt#LL292C15-L292C15), which I think should be a reasonable replacement for that spec. Open to other alternatives though!

I've also made a somewhat janky update to the `test.yml` Github action runner, which will specify a valid version for the action to call `gem update` on for Ruby 2.5. If there's a better way to leverage the Github action yaml syntax, I am very open to a better way than what I added there!

Screenshot with the build error here, for posterity. The spec runner deletes logs after a while, so I wanted to preserve here.
<img width="770" alt="Screen Shot 2023-05-16 at 6 46 22 PM" src="https://github.com/pdfkit/pdfkit/assets/63384617/6acb105f-5c79-44da-a1c6-8aaa39f2e55e">