### PR TITLE
adds default config for compatibility with wkhtmltopdf 0.12.6

### DIFF
--- a/lib/pdfkit/configuration.rb
+++ b/lib/pdfkit/configuration.rb
@@ -11,6 +11,7 @@ class PDFKit
       @use_xvfb        = false
       @meta_tag_prefix = 'pdfkit-'
       @default_options = {
+        :enable_local_file_access => true,
         :disable_smart_shrinking => false,
         :quiet => true,
         :page_size => 'Letter',


### PR DESCRIPTION
Recent versions of wkhtmltopdf disable local file access by default. With this PR we enable it by default when using PDFKit.

I have a minimal example that reproduces the problem here: https://github.com/ptolemybarnes/pdfkit-issue/blob/main/spec/pdfkit_issue_spec.rb
