### PR TITLE
Handle empty/missing meta contents

### DIFF
--- a/lib/pdfkit/pdfkit.rb
+++ b/lib/pdfkit/pdfkit.rb
@@ -95,7 +95,8 @@ class PDFKit
     content.scan(/<meta [^>]*>/) do |meta|
       if meta.match(/name=["']#{PDFKit.configuration.meta_tag_prefix}/)
         name = meta.scan(/name=["']#{PDFKit.configuration.meta_tag_prefix}([^"']*)/)[0][0].split
-        found[name] = meta.scan(/content=["']([^"'\\]+)["']/)[0][0]
+        content = meta.scan(/content=["']([^"'\\]*)["']/)[0]
+        found[name] = content[0] if content
       end
     end
 

--- a/spec/pdfkit_spec.rb
+++ b/spec/pdfkit_spec.rb
@@ -385,6 +385,22 @@ describe PDFKit do
       expect(command).to contain %w[--orientation Landscape]
     end
 
+    it "handles empty meta tags" do
+      body = %{
+        <html>
+          <head>
+            <meta name="pdfkit-footer_html"/>
+            <meta name="pdfkit-header_html" content=""/>
+          </head>
+          <br>
+        </html>
+      }
+      pdfkit = PDFKit.new(body)
+      command = pdfkit.command
+      expect(command).not_to contain %w[--footer-html]
+      expect(command).to contain ["--header-html", ""]
+    end
+
     it "does not use quiet when told to" do
       pdfkit = PDFKit.new('html', quiet: false)
       expect(pdfkit.command).not_to include '--quiet'


### PR DESCRIPTION
We allow our templates to be customized by end users (via liquid) and need to be robust in the face of "invalid" options, such as:

```
    <meta name="description" content="Demo Invoice">
    <meta name="author" content="Demo Invoice">
    <meta http-equiv="X-UA-Compatible" content="IE=edge">
    <meta name="pdfkit-header_html" content="">
    <meta name="pdfkit-footer_html" content="{{ footer_url }}">
```

There was a change way back in https://github.com/pdfkit/pdfkit/commit/4f971f4920bceccab7821caedec35f392e9baa97 (released in v0.6.2) that changed the `content` parser such that line 4 here would raise an error.

This PR changes that parsing regexp from `+` to `*` allowing emptystring fields to be passed through, and also be robust in the face of a `pdfkit-` meta tag with no content attribute.

