### PR TITLE
chore/allowing-multi-sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+2025-06-02
+=================
+  * Add support for multiple sources in PDF generation
+  * Modify PDFKit to handle an array of HTML strings, URLs, and files
+  * Maintain backward compatibility with single source usage
+
 2023-02-27
 =================
   * Bump to 0.8.7.3

--- a/README.md
+++ b/README.md
@@ -43,6 +43,12 @@ file = kit.to_file('/path/to/save/pdf')
 kit = PDFKit.new('http://google.com')
 kit = PDFKit.new(File.new('/path/to/html'))
 
+# PDFKit can also accept multiple sources (HTML strings, URLs, or Files)
+# This allows you to combine multiple documents into a single PDF
+kit = PDFKit.new(['<h1>First page</h1>', '<h1>Second page</h1>'])
+kit = PDFKit.new(['http://google.com', 'http://yahoo.com'])
+kit = PDFKit.new([File.new('/path/to/html'), '<h1>Appended content</h1>'])
+
 # Add any kind of option through meta tags
 PDFKit.new('<html><head><meta name="pdfkit-page_size" content="Letter"')
 PDFKit.new('<html><head><meta name="pdfkit-cookie cookie_name1" content="cookie_value1"')

--- a/lib/pdfkit/pdfkit.rb
+++ b/lib/pdfkit/pdfkit.rb
@@ -26,17 +26,20 @@ class PDFKit
     end
   end
 
-  attr_accessor :source, :stylesheets
+  attr_accessor :sources, :stylesheets
   attr_reader :renderer
 
   def initialize(url_file_or_html, options = {})
-    @source = Source.new(url_file_or_html)
+    @sources = []
+    url_file_or_html = [url_file_or_html] unless url_file_or_html.is_a? Array
+
+    url_file_or_html.each { |source| @sources << Source.new(source) }
 
     @stylesheets = []
 
     options = PDFKit.configuration.default_options.merge(options)
     options.delete(:quiet) if PDFKit.configuration.verbose?
-    options.merge! find_options_in_meta(url_file_or_html) unless source.url?
+    options.merge! find_options_in_meta(url_file_or_html) unless sources.any?(&:url?)
     @root_url = options.delete(:root_url)
     @protocol = options.delete(:protocol)
     @renderer = WkHTMLtoPDF.new options
@@ -48,7 +51,9 @@ class PDFKit
   def command(path = nil)
     args = [*executable]
     args.concat(@renderer.options_for_command)
-    args << @source.to_input_for_command
+    @sources.each do |source|
+      args << source.to_input_for_command
+    end
     args << (path ? path.to_s : '-')
     args
   end
@@ -69,7 +74,7 @@ class PDFKit
     invoke = command(path)
 
     result = IO.popen(invoke, "wb+") do |pdf|
-      pdf.puts(@source.to_s) if @source.html?
+      @sources.each { |source| pdf.puts(source.to_s) if source.html? }
       pdf.close_write
       pdf.gets(nil) if path.nil?
     end
@@ -85,26 +90,33 @@ class PDFKit
     File.new(path)
   end
 
+  def source
+    return @sources.first if @sources.length == 1
+    @sources
+  end
+
   protected
 
-  def find_options_in_meta(content)
+  def find_options_in_meta(contents)
     # Read file if content is a File
-    content = content.read if content.is_a?(File) || content.is_a?(Tempfile)
-
     found = {}
-    content.scan(/<meta [^>]*>/) do |meta|
-      if meta.match(/name=["']#{PDFKit.configuration.meta_tag_prefix}/)
-        name = meta.scan(/name=["']#{PDFKit.configuration.meta_tag_prefix}([^"']*)/)[0][0].split
-        found[name] = meta.scan(/content=["']([^"'\\]+)["']/)[0][0]
-      end
-    end
+    contents.each do |content|
+      content = content.read if content.is_a?(File) || content.is_a?(Tempfile)
 
-    tuple_keys = found.keys.select { |k| k.is_a? Array }
-    tuple_keys.each do |key|
-      value = found.delete key
-      new_key = key.shift
-      found[new_key] ||= {}
-      found[new_key][key] = value
+      content.scan(/<meta [^>]*>/) do |meta|
+        if meta.match(/name=["']#{PDFKit.configuration.meta_tag_prefix}/)
+          name = meta.scan(/name=["']#{PDFKit.configuration.meta_tag_prefix}([^"']*)/)[0][0].split
+          found[name] = meta.scan(/content=["']([^"'\\]+)["']/)[0][0]
+        end
+      end
+
+      tuple_keys = found.keys.select { |k| k.is_a? Array }
+      tuple_keys.each do |key|
+        value = found.delete key
+        new_key = key.shift
+        found[new_key] ||= {}
+        found[new_key][key] = value
+      end
     end
 
     found
@@ -117,22 +129,28 @@ class PDFKit
   end
 
   def preprocess_html
-    if @source.html?
-      processed_html = PDFKit::HTMLPreprocessor.process(@source.to_s, @root_url, @protocol)
-      @source = Source.new(processed_html)
+    @sources.map! do |source|
+      if source.html?
+        processed_html = PDFKit::HTMLPreprocessor.process(source.to_s, @root_url, @protocol)
+        Source.new(processed_html)
+      else
+        source
+      end
     end
   end
 
   def append_stylesheets
-    raise ImproperSourceError, 'Stylesheets may only be added to an HTML source' if stylesheets.any? && !@source.html?
+    raise ImproperSourceError, 'Stylesheets may only be added to an HTML source' if stylesheets.any? && !@sources.any?(&:html?)
 
     stylesheets.each do |stylesheet|
-      if @source.to_s.match(/<\/head>/)
-        @source = Source.new(@source.to_s.gsub(/(<\/head>)/) {|s|
-          style_tag_for(stylesheet) + (s.respond_to?(:html_safe) ? s.html_safe : s)
-        })
-      else
-        @source.to_s.insert(0, style_tag_for(stylesheet))
+      @sources.map! do |source|
+        if source.to_s.match(/<\/head>/)
+          Source.new(source.to_s.gsub(/(<\/head>)/) {|s|
+            style_tag_for(stylesheet) + (s.respond_to?(:html_safe) ? s.html_safe : s)
+          })
+        else
+          Source.new(source.to_s.insert(0, style_tag_for(stylesheet)))
+        end
       end
     end
   end

--- a/lib/pdfkit/version.rb
+++ b/lib/pdfkit/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class PDFKit
-  VERSION = '0.8.7.3'
+  VERSION = '0.8.8.0'
 end

--- a/spec/pdfkit_spec.rb
+++ b/spec/pdfkit_spec.rb
@@ -32,6 +32,13 @@ describe PDFKit do
       expect(pdfkit.source.to_s).to match(/^#{Dir.tmpdir}/)
     end
 
+    it "accepts multiple sources in an array" do
+      pdfkit = PDFKit.new(['<h1>Oh Hai</h1>', 'http://google.com'])
+      expect(pdfkit.sources.length).to eq(2)
+      expect(pdfkit.sources[0]).to be_html
+      expect(pdfkit.sources[1]).to be_url
+    end
+
     # Options
     ## options keys
     it "drops options without values" do
@@ -478,6 +485,12 @@ describe PDFKit do
       expect(pdf[0...4]).to eq("%PDF") # PDF Signature at beginning of file
     end
 
+    it "generates a PDF of the HTML with multiple sources" do
+      pdfkit = PDFKit.new(['http://google.com', 'https://www.google.com/search?q=pdfkit&sort=DESC'], :page_size => 'Letter')
+      pdf = pdfkit.to_pdf
+      expect(pdf[0...4]).to eq("%PDF") # PDF Signature at beginning of file
+    end
+
     it "generates a PDF with a numerical parameter" do
       pdfkit = PDFKit.new('html', :header_spacing => 1)
       pdf = pdfkit.to_pdf
@@ -603,6 +616,18 @@ describe PDFKit do
       pdfkit = PDFKit.new('html', :header_center => "a title\"; touch #{@test_path} #")
       pdfkit.to_pdf
       expect(File.exist?(@test_path)).to eq(false)
+    end
+  end
+
+  describe "#source" do
+    it 'returns all the sources as an Array' do
+      pdfkit = PDFKit.new(['html', 'wkhtmltopdf'], :page_size => 'Letter')
+      expect(pdfkit.source.class).to eq(Array)
+    end
+
+    it 'returns the first source when there is a single source' do
+      pdfkit = PDFKit.new('html', :page_size => 'Letter')
+      expect(pdfkit.source).to eq(pdfkit.sources.first)
     end
   end
 end


### PR DESCRIPTION
This pull request introduces support for multiple sources in PDF generation, allowing users to combine various HTML strings, URLs, and files into a single PDF. The changes ensure backward compatibility with single-source usage while updating relevant methods, documentation, and tests.

### Feature Addition: Support for Multiple Sources in PDF Generation
* [`lib/pdfkit/pdfkit.rb`](diffhunk://#diff-6751c1216a4a15874d4f90bfc7a74d82cc15274434bdc6c5bc3d0ed1a3503c56L29-R42): Updated `initialize` method to accept an array of sources and process each individually. Modified methods like `command`, `to_pdf`, and `preprocess_html` to handle multiple sources seamlessly. Added a new `source` method to return either the first source or all sources as an array. [[1]](diffhunk://#diff-6751c1216a4a15874d4f90bfc7a74d82cc15274434bdc6c5bc3d0ed1a3503c56L29-R42) [[2]](diffhunk://#diff-6751c1216a4a15874d4f90bfc7a74d82cc15274434bdc6c5bc3d0ed1a3503c56L51-R56) [[3]](diffhunk://#diff-6751c1216a4a15874d4f90bfc7a74d82cc15274434bdc6c5bc3d0ed1a3503c56L72-R77) [[4]](diffhunk://#diff-6751c1216a4a15874d4f90bfc7a74d82cc15274434bdc6c5bc3d0ed1a3503c56R93-L94) [[5]](diffhunk://#diff-6751c1216a4a15874d4f90bfc7a74d82cc15274434bdc6c5bc3d0ed1a3503c56L120-R153)
* [`lib/pdfkit/version.rb`](diffhunk://#diff-cd13bfa5206288d9220832f679ffa16e2b6d31db1cc0ceea5ad0ed5a36295a59L4-R4): Bumped version to `0.8.8.0` to reflect the new feature.

### Documentation Updates
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R46-R51): Added examples demonstrating the usage of multiple sources, including combining HTML strings, URLs, and files into a single PDF.
* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR1-R6): Documented the addition of support for multiple sources and the backward compatibility with single-source usage.

### Test Enhancements
* [`spec/pdfkit_spec.rb`](diffhunk://#diff-9b79b129b1b8eb06def4cadf191db6cae44c35bb20dbb3bb0a391d834c8b67a4R35-R41): Added tests to verify the behavior of multiple sources, including their processing and PDF generation. Tests ensure the `source` method works correctly for single and multiple sources. [[1]](diffhunk://#diff-9b79b129b1b8eb06def4cadf191db6cae44c35bb20dbb3bb0a391d834c8b67a4R35-R41) [[2]](diffhunk://#diff-9b79b129b1b8eb06def4cadf191db6cae44c35bb20dbb3bb0a391d834c8b67a4R488-R493) [[3]](diffhunk://#diff-9b79b129b1b8eb06def4cadf191db6cae44c35bb20dbb3bb0a391d834c8b67a4R621-R632)